### PR TITLE
Add as_ref to Script

### DIFF
--- a/amzn-smt-ir/src/script.rs
+++ b/amzn-smt-ir/src/script.rs
@@ -48,6 +48,12 @@ impl<Term> IntoIterator for Script<Term> {
     }
 }
 
+impl<Term> AsRef<[Command<Term>]> for Script<Term> {
+    fn as_ref(&self) -> &[Command<Term>] {
+        &self.commands
+    }
+}
+
 impl<Term> Extend<Command<Term>> for Script<Term> {
     fn extend<T: IntoIterator<Item = Command<Term>>>(&mut self, iter: T) {
         self.commands.extend(iter)


### PR DESCRIPTION
Added `as_ref` to `Script`, as it's common for wrapper types (such as in other types in this code base), in order to have access to slice functions, immutable reference iterators, for loop iterate, etc.
My specific use case that led to this was immutable reference iterators, as I wanted to traverse the commands (besides `assert` so couldn't use `visit_asserted`) to collect information without creating a new Script, and this felt cleaner than running a `map` over the commands since I'm not creating new commands.
I'm using this in my fork, so wanted to offer it upstream.
In any case, thanks for writing the lib!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
