### PR TITLE
fix conversion of push nodes into the IR

### DIFF
--- a/amzn-smt-ir/src/term/convert.rs
+++ b/amzn-smt-ir/src/term/convert.rs
@@ -634,7 +634,7 @@ mod visitors {
         }
 
         fn visit_push(&mut self, level: smt2parser::Numeral) -> Result<Self::T, Self::E> {
-            Ok(Command::Pop { level })
+            Ok(Command::Push { level })
         }
 
         fn visit_reset(&mut self) -> Result<Self::T, Self::E> {

--- a/aws-smt-ir/src/term/convert.rs
+++ b/aws-smt-ir/src/term/convert.rs
@@ -634,7 +634,7 @@ mod visitors {
         }
 
         fn visit_push(&mut self, level: smt2parser::Numeral) -> Result<Self::T, Self::E> {
-            Ok(Command::Pop { level })
+            Ok(Command::Push { level })
         }
 
         fn visit_reset(&mut self) -> Result<Self::T, Self::E> {


### PR DESCRIPTION
*Issue #, if available:* n/a; small issue

*Description of changes:*
Change the conversion of Push nodes to correctly be Push nodes in the IR rather than Pop nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
