### PR TITLE
Fix smt2parser

### DIFF
--- a/aws-smt-ir-derive/Cargo.toml
+++ b/aws-smt-ir-derive/Cargo.toml
@@ -18,8 +18,8 @@ publish = true
 proc-macro = true
 
 [dependencies]
-synstructure = "0.12"
+synstructure = "0.13"
 quote = "1.0"
 proc-macro2 = "1.0"
 proc-macro-crate = "1.0"
-syn = { version = "1.0", features = ["full", "fold"] }
+syn = { version = "2.0", features = ["full", "fold"] }

--- a/aws-smt-ir-derive/src/lib.rs
+++ b/aws-smt-ir-derive/src/lib.rs
@@ -23,7 +23,7 @@ fn smt_ir_crate_path() -> syn::Path {
 
 /// Determines whether `input` is annotated with the `#[core_op]` attribute.
 fn has_core_op_attr(input: &DeriveInput) -> bool {
-    input.attrs.iter().any(|a| a.path.is_ident("core_op"))
+    input.attrs.iter().any(|a| a.path().is_ident("core_op"))
 }
 
 // Determine a variant's symbol (its representation in SMT-LIB) -- either the lowercased name of
@@ -31,7 +31,7 @@ fn has_core_op_attr(input: &DeriveInput) -> bool {
 fn variant_symbol(variant: &synstructure::VariantInfo) -> syn::LitStr {
     let ast = variant.ast();
     (ast.attrs.iter())
-        .find(|attr| attr.path.is_ident("symbol"))
+        .find(|attr| attr.path().is_ident("symbol"))
         .and_then(|attr| attr.parse_args().ok())
         .unwrap_or_else(|| {
             let name = ast.ident.to_string().to_lowercase();

--- a/aws-smt-ir/Cargo.toml
+++ b/aws-smt-ir/Cargo.toml
@@ -18,17 +18,23 @@ publish = true
 aws-smt-ir-derive = "0.1.0"
 either = "1.6"
 internment = { version = "0.7.0", features = ["intern"] }
-itertools = "0.10"
+itertools = "0.11"
 num-traits = "0.2"
 once_cell = "1.8"
 smallvec = { version = "1.6", features = ["union"] }
-smt2parser = "0.6.1"
 stacker = "0.1"
 thiserror = "1.0"
 varisat = { version = "0.2", optional = true }
+# dependencies for smt2parser
+num = { version = "0.4", features = ["serde"] }
+pomelo = "0.1.5"
+fst = "0.4.5"
+serde = { version = "1.0.125", features = ["derive"] }
+permutation_iterator = "0.1.2"
+strum = { version = "0.25", features = ["derive"] }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5"
 paste = "1.0"
 static_assertions = "1.1"
 varisat = "0.2"

--- a/aws-smt-ir/benches/parsing.rs
+++ b/aws-smt-ir/benches/parsing.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use aws_smt_ir::smt2parser::{concrete::SyntaxBuilder, CommandStream};
 use aws_smt_ir::{logic::QF_LIA, Logic, QualIdentifier, Script, Term};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use smt2parser::{concrete::SyntaxBuilder, CommandStream};
 use std::{fs::File, io::BufReader, path::Path, process::Command};
 
 const QFLIA_FILES: &[&str] = &[

--- a/aws-smt-ir/src/fold.rs
+++ b/aws-smt-ir/src/fold.rs
@@ -12,9 +12,9 @@ pub use compose::{Compose, TryComposed};
 mod intra;
 pub use intra::IntraLogicFolder;
 mod inter;
+use crate::smt2parser::Numeral;
 pub use inter::InterLogicFolder;
 use smallvec::SmallVec;
-use smt2parser::Numeral;
 
 /// A `Folder<T>` is a type that can be used to transform SMT terms in logic `T` to some other type.
 /// For example, a folder could be used to partially evaluate a term or encode it into a simpler
@@ -698,7 +698,7 @@ impl<L: Logic, Out> Fold<L, Out> for Command<Term<L>> {
     where
         F: Folder<L, M, Output = Out>,
     {
-        use smt2parser::concrete::Command::*;
+        use crate::smt2parser::concrete::Command::*;
         if let Some(ctx) = folder.context_mut() {
             ctx.process(&self);
         }

--- a/aws-smt-ir/src/lib.rs
+++ b/aws-smt-ir/src/lib.rs
@@ -6,13 +6,20 @@
 use itertools::Itertools;
 pub use smallvec::smallvec as args;
 use smallvec::SmallVec;
-use smt2parser::{concrete::Command as Smt2ParserCommand, concrete::SyntaxBuilder, CommandStream};
 use std::{convert::Infallible, io};
 
 // This renaming is necessary for the derive macros to work in doctests/integration tests, since
 // `proc_macro_crate` can't distinguish between those contexts (treated as separate crates) and
 // normal code/tests inside the crate.
 extern crate self as aws_smt_ir;
+
+#[macro_use]
+extern crate pomelo;
+
+pub mod smt2parser;
+pub use smt2parser::{
+    concrete::Command as Smt2ParserCommand, concrete::SyntaxBuilder, CommandStream,
+};
 
 pub mod ackermann;
 pub mod cnf;

--- a/aws-smt-ir/src/logic/bitvecs.rs
+++ b/aws-smt-ir/src/logic/bitvecs.rs
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use crate::smt2parser::Numeral;
 use crate::{
     fold::Fold, visit::Visit, Ctx, IIndex, ISort, Index, Logic, Operation, QualIdentifier, Sorted,
     Term, UnknownSort, Void, UF,
 };
 use num_traits::One;
 use smallvec::SmallVec;
-use smt2parser::Numeral;
 
 type Args<T> = SmallVec<[T; 2]>;
 

--- a/aws-smt-ir/src/script.rs
+++ b/aws-smt-ir/src/script.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use crate::smt2parser::{CommandStream, Numeral};
 use crate::{
     convert::{Converter, InvalidTerm},
     fold::{Fold, Folder},
@@ -7,7 +8,6 @@ use crate::{
     visit::{ControlFlow, Visit, Visitor},
     Command, ISort, ISymbol, IVar, Logic, QualIdentifier, Term,
 };
-use smt2parser::{CommandStream, Numeral};
 use std::{
     collections::HashMap,
     convert::Infallible,
@@ -63,7 +63,7 @@ impl<Term> Extend<Command<Term>> for Script<Term> {
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError<L: Logic> {
     #[error("malformed SMT-LIB input: {0}")]
-    Smt2Parser(#[from] smt2parser::Error),
+    Smt2Parser(#[from] crate::smt2parser::Error),
     #[error("invalid SMT-LIB expression in logic {0:?}: {1}")]
     Conversion(L, InvalidTerm<L>),
 }
@@ -282,7 +282,7 @@ impl Ctx {
     }
 
     pub(crate) fn process<T>(&mut self, command: &Command<T>) {
-        use smt2parser::concrete::Command::*;
+        use crate::smt2parser::concrete::Command::*;
         match command {
             DeclareSort { symbol, arity } => self.declare_sort(symbol.clone(), arity.clone()),
             DeclareFun {

--- a/aws-smt-ir/src/smt2parser.rs
+++ b/aws-smt-ir/src/smt2parser.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Summary of Amazon changes
+// - import smt2parser as a module in aws_smt_ir
+// - remove the `smt2parser::stats` module (not used here)
+
+//! This crate provides a generic parser for SMT2 commands, as specified by the
+//! [SMT-LIB-2 standard](http://smtlib.cs.uiowa.edu/language.shtml).
+//!
+//! Commands are parsed and immediately visited by a user-provided
+//! implementation of the trait [`visitors::Smt2Visitor`].
+//!
+//! To obtain concrete syntax values, use [`concrete::SyntaxBuilder`] as a
+//! visitor:
+//! ```
+//! # use aws_smt_ir::smt2parser::{CommandStream, concrete};
+//! let input = b"(echo \"Hello world!\")(exit)";
+//! let stream = CommandStream::new(
+//!     &input[..],
+//!     concrete::SyntaxBuilder,
+//!     Some("optional/path/to/file".to_string()),
+//! );
+//! let commands = stream.collect::<Result<Vec<_>, _>>().unwrap();
+//! assert!(matches!(commands[..], [
+//!     concrete::Command::Echo {..},
+//!     concrete::Command::Exit,
+//! ]));
+//! assert_eq!(commands[0].to_string(), "(echo \"Hello world!\")");
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod concrete;
+mod lexer;
+mod parser;
+pub mod renaming;
+pub mod rewriter;
+pub mod visitors;
+
+/// SMT2 numeral values.
+pub type Numeral = num::bigint::BigUint;
+/// SMT2 decimal values.
+pub type Decimal = num::rational::BigRational;
+/// A base-16 digit.
+pub type Nibble = u8;
+/// SMT2 hexadecimal values.
+pub type Hexadecimal = Vec<Nibble>;
+/// SMT2 binary values.
+pub type Binary = Vec<bool>;
+
+/// A minimal error type.
+pub use concrete::Error;
+/// A position in the input.
+pub use lexer::Position;
+
+/// Parse the input data and return a stream of interpreted SMT2 commands
+pub struct CommandStream<R, T>
+where
+    R: std::io::BufRead,
+    T: visitors::Smt2Visitor,
+{
+    lexer: lexer::Lexer<R>,
+    visitor: T,
+    position: Position,
+}
+
+impl<R, T> CommandStream<R, T>
+where
+    R: std::io::BufRead,
+    T: visitors::Smt2Visitor,
+{
+    pub fn new(reader: R, visitor: T, path: Option<String>) -> Self {
+        Self {
+            lexer: lexer::Lexer::new(reader),
+            visitor,
+            position: Position {
+                path,
+                ..Position::default()
+            },
+        }
+    }
+
+    pub fn visitor(&self) -> &T {
+        &self.visitor
+    }
+
+    pub fn visitor_mut(&mut self) -> &mut T {
+        &mut self.visitor
+    }
+
+    pub fn into_visitor(self) -> T {
+        self.visitor
+    }
+}
+
+impl<R, T> Iterator for CommandStream<R, T>
+where
+    R: std::io::BufRead,
+    T: visitors::Smt2Visitor,
+{
+    type Item = Result<T::Command, T::Error>;
+
+    #[allow(clippy::while_let_on_iterator)]
+    fn next(&mut self) -> Option<Result<T::Command, T::Error>> {
+        let mut parser = parser::Parser::new((&mut self.visitor, &mut self.position));
+        let mut unmatched_paren = 0;
+        while let Some(token) = self.lexer.next() {
+            match &token {
+                parser::Token::LeftParen => unmatched_paren += 1,
+                parser::Token::RightParen => {
+                    if unmatched_paren > 0 {
+                        unmatched_paren -= 1;
+                    }
+                }
+                _ => (),
+            }
+            self.lexer.update_position(parser.extra_mut().1);
+            if let Err(err) = parser.parse(token) {
+                return Some(Err(err));
+            }
+            if unmatched_paren == 0 {
+                return match parser.end_of_input() {
+                    Ok((command, _)) => Some(Ok(command)),
+                    Err(err) => Some(Err(err)),
+                };
+            }
+        }
+        if unmatched_paren > 0 {
+            // We ran out of valid tokens in the middle of a command.
+            let extra = parser.into_extra();
+            Some(Err(extra.0.parsing_error(
+                extra.1.clone(),
+                "unexpected end of input".into(),
+            )))
+        } else {
+            // There are no more valid tokens to parse.
+            // TODO: report invalid tokens as an error.
+            None
+        }
+    }
+}
+
+#[test]
+fn test_command_stream_error() {
+    let input = b"(echo \"Hello world!\")(exit f)";
+    let builder = concrete::SyntaxBuilder::default();
+    let stream = CommandStream::new(&input[..], builder, None);
+    let commands = stream.collect::<Vec<_>>();
+    assert!(matches!(
+        commands[..],
+        [
+            Ok(concrete::Command::Echo { .. }),
+            Err(concrete::Error::SyntaxError(..)),
+            Err(concrete::Error::SyntaxError(..)),
+        ]
+    ));
+    assert_eq!(
+        commands[0].as_ref().unwrap().to_string(),
+        "(echo \"Hello world!\")"
+    );
+}
+
+#[test]
+fn test_command_stream_invalid_token() {
+    let input = b"(echo \"Hello world!\")(exit \000)";
+    let builder = concrete::SyntaxBuilder::default();
+    let stream = CommandStream::new(&input[..], builder, None);
+    let commands = stream.collect::<Vec<_>>();
+    assert!(matches!(
+        commands[..],
+        [
+            Ok(concrete::Command::Echo { .. }),
+            Err(concrete::Error::ParsingError(..)),
+        ]
+    ));
+    assert_eq!(
+        commands[0].as_ref().unwrap().to_string(),
+        "(echo \"Hello world!\")"
+    );
+}

--- a/aws-smt-ir/src/smt2parser.rs
+++ b/aws-smt-ir/src/smt2parser.rs
@@ -145,7 +145,7 @@ where
 #[test]
 fn test_command_stream_error() {
     let input = b"(echo \"Hello world!\")(exit f)";
-    let builder = concrete::SyntaxBuilder::default();
+    let builder = concrete::SyntaxBuilder;
     let stream = CommandStream::new(&input[..], builder, None);
     let commands = stream.collect::<Vec<_>>();
     assert!(matches!(
@@ -164,8 +164,8 @@ fn test_command_stream_error() {
 
 #[test]
 fn test_command_stream_invalid_token() {
-    let input = b"(echo \"Hello world!\")(exit \000)";
-    let builder = concrete::SyntaxBuilder::default();
+    let input = b"(echo \"Hello world!\")(exit \x0000)";
+    let builder = concrete::SyntaxBuilder;
     let stream = CommandStream::new(&input[..], builder, None);
     let commands = stream.collect::<Vec<_>>();
     assert!(matches!(

--- a/aws-smt-ir/src/smt2parser/concrete.rs
+++ b/aws-smt-ir/src/smt2parser/concrete.rs
@@ -1111,7 +1111,7 @@ impl std::fmt::Display for Constant {
 
 impl std::fmt::Display for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let c = self.0.as_bytes().get(0);
+        let c = self.0.as_bytes().first();
         if c.is_some()
             && lexer::is_non_digit_symbol_byte(*c.unwrap())
             && self.0.as_bytes().iter().all(|c| lexer::is_symbol_byte(*c))
@@ -1440,7 +1440,7 @@ fn test_syntax_visitor() {
             }),
         },
     };
-    let mut builder = SyntaxBuilder::default();
+    let mut builder = SyntaxBuilder;
     let command2 = command.clone().accept(&mut builder).unwrap();
     assert_eq!(command, command2);
 }

--- a/aws-smt-ir/src/smt2parser/concrete.rs
+++ b/aws-smt-ir/src/smt2parser/concrete.rs
@@ -1,0 +1,1446 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//! A concrete syntax tree together with building functions (aka parser visitors) and SEXP-printing functions.
+
+use crate::smt2parser::{
+    lexer,
+    visitors::{
+        CommandVisitor, ConstantVisitor, KeywordVisitor, QualIdentifierVisitor, SExprVisitor,
+        Smt2Visitor, SortVisitor, SymbolKind, SymbolVisitor, TermVisitor,
+    },
+    Binary, Decimal, Hexadecimal, Numeral, Position,
+};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Concrete syntax for a constant.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum Constant {
+    Numeral(Numeral),
+    Decimal(Decimal),
+    Hexadecimal(Hexadecimal),
+    Binary(Binary),
+    String(String),
+}
+
+/// Concrete symbol.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct Symbol(pub String);
+
+/// Concrete keyword.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct Keyword(pub String);
+
+pub use crate::smt2parser::visitors::Identifier;
+
+/// Concrete syntax for an S-expression.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum SExpr<Constant = self::Constant, Symbol = self::Symbol, Keyword = self::Keyword> {
+    Constant(Constant),
+    Symbol(Symbol),
+    Keyword(Keyword),
+    Application(Vec<Self>),
+}
+
+pub use crate::smt2parser::visitors::{AttributeValue, DatatypeDec, FunctionDec};
+
+/// Concrete syntax for a sort.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum Sort<Identifier = self::Identifier> {
+    Simple {
+        identifier: Identifier,
+    },
+    Parameterized {
+        identifier: Identifier,
+        parameters: Vec<Self>,
+    },
+}
+
+/// Concrete syntax for a qualified-identifier.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum QualIdentifier<Identifier = self::Identifier, Sort = self::Sort> {
+    Simple { identifier: Identifier },
+    Sorted { identifier: Identifier, sort: Sort },
+}
+
+/// Concrete syntax for a term.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum Term<
+    Constant = self::Constant,
+    QualIdentifier = self::QualIdentifier,
+    Keyword = self::Keyword,
+    SExpr = self::SExpr,
+    Symbol = self::Symbol,
+    Sort = self::Sort,
+> {
+    Constant(Constant),
+    QualIdentifier(QualIdentifier),
+    Application {
+        qual_identifier: QualIdentifier,
+        arguments: Vec<Self>,
+    },
+    Let {
+        var_bindings: Vec<(Symbol, Self)>,
+        term: Box<Self>,
+    },
+    Forall {
+        vars: Vec<(Symbol, Sort)>,
+        term: Box<Self>,
+    },
+    Exists {
+        vars: Vec<(Symbol, Sort)>,
+        term: Box<Self>,
+    },
+    Match {
+        term: Box<Self>,
+        cases: Vec<(Vec<Symbol>, Self)>,
+    },
+    Attributes {
+        term: Box<Self>,
+        attributes: Vec<(Keyword, AttributeValue<Constant, Symbol, SExpr>)>,
+    },
+}
+
+/// Concrete syntax for a command.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum Command<
+    Term = self::Term,
+    Symbol = self::Symbol,
+    Sort = self::Sort,
+    Keyword = self::Keyword,
+    Constant = self::Constant,
+    SExpr = self::SExpr,
+> {
+    Assert {
+        term: Term,
+    },
+    CheckSat,
+    CheckSatAssuming {
+        literals: Vec<(Symbol, bool)>,
+    },
+    DeclareConst {
+        symbol: Symbol,
+        sort: Sort,
+    },
+    DeclareDatatype {
+        symbol: Symbol,
+        datatype: DatatypeDec<Symbol, Sort>,
+    },
+    DeclareDatatypes {
+        datatypes: Vec<(Symbol, Numeral, DatatypeDec<Symbol, Sort>)>,
+    },
+    DeclareFun {
+        symbol: Symbol,
+        parameters: Vec<Sort>,
+        sort: Sort,
+    },
+    DeclareSort {
+        symbol: Symbol,
+        arity: Numeral,
+    },
+    DefineFun {
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    },
+    DefineFunRec {
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    },
+    DefineFunsRec {
+        funs: Vec<(FunctionDec<Symbol, Sort>, Term)>,
+    },
+    DefineSort {
+        symbol: Symbol,
+        parameters: Vec<Symbol>,
+        sort: Sort,
+    },
+    Echo {
+        message: String,
+    },
+    Exit,
+    GetAssertions,
+    GetAssignment,
+    GetInfo {
+        flag: Keyword,
+    },
+    GetModel,
+    GetOption {
+        keyword: Keyword,
+    },
+    GetProof,
+    GetUnsatAssumptions,
+    GetUnsatCore,
+    GetValue {
+        terms: Vec<Term>,
+    },
+    Pop {
+        level: Numeral,
+    },
+    Push {
+        level: Numeral,
+    },
+    Reset,
+    ResetAssertions,
+    SetInfo {
+        keyword: Keyword,
+        value: AttributeValue<Constant, Symbol, SExpr>,
+    },
+    SetLogic {
+        symbol: Symbol,
+    },
+    SetOption {
+        keyword: Keyword,
+        value: AttributeValue<Constant, Symbol, SExpr>,
+    },
+}
+
+/// An implementation of [`Smt2Visitor`] that returns concrete syntax values.
+#[derive(Default, Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
+pub struct SyntaxBuilder;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("error: {1}\n   --> {0}")]
+    SyntaxError(Position, String),
+    #[error("error: {1}\n   --> {0}")]
+    ParsingError(Position, String),
+}
+
+impl ConstantVisitor for SyntaxBuilder {
+    type T = Constant;
+    type E = Error;
+
+    fn visit_numeral_constant(&mut self, value: Numeral) -> Result<Self::T, Self::E> {
+        Ok(Constant::Numeral(value))
+    }
+    fn visit_decimal_constant(&mut self, value: Decimal) -> Result<Self::T, Self::E> {
+        Ok(Constant::Decimal(value))
+    }
+    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Result<Self::T, Self::E> {
+        Ok(Constant::Hexadecimal(value))
+    }
+    fn visit_binary_constant(&mut self, value: Binary) -> Result<Self::T, Self::E> {
+        Ok(Constant::Binary(value))
+    }
+    fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E> {
+        Ok(Constant::String(value))
+    }
+}
+
+impl Constant {
+    /// Visit a concrete constant.
+    pub fn accept<V>(self, visitor: &mut V) -> Result<V::T, V::E>
+    where
+        V: ConstantVisitor,
+    {
+        use Constant::*;
+        match self {
+            Numeral(value) => visitor.visit_numeral_constant(value),
+            Decimal(value) => visitor.visit_decimal_constant(value),
+            Hexadecimal(value) => visitor.visit_hexadecimal_constant(value),
+            Binary(value) => visitor.visit_binary_constant(value),
+            String(value) => visitor.visit_string_constant(value),
+        }
+    }
+}
+
+impl SymbolVisitor for SyntaxBuilder {
+    type T = Symbol;
+    type E = Error;
+
+    fn visit_fresh_symbol(&mut self, value: String, _kind: SymbolKind) -> Result<Self::T, Self::E> {
+        Ok(Symbol(value))
+    }
+}
+
+impl KeywordVisitor for SyntaxBuilder {
+    type T = Keyword;
+    type E = Error;
+
+    fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E> {
+        Ok(Keyword(value))
+    }
+}
+
+impl Keyword {
+    /// Visit a concrete keyword.
+    pub fn accept<V>(self, visitor: &mut V) -> Result<V::T, V::E>
+    where
+        V: KeywordVisitor,
+    {
+        visitor.visit_keyword(self.0)
+    }
+}
+
+impl<Constant, Symbol, Keyword> SExprVisitor<Constant, Symbol, Keyword> for SyntaxBuilder {
+    type T = SExpr<Constant, Symbol, Keyword>;
+    type E = Error;
+
+    fn visit_constant_s_expr(&mut self, value: Constant) -> Result<Self::T, Self::E> {
+        Ok(SExpr::Constant(value))
+    }
+
+    fn visit_symbol_s_expr(&mut self, value: Symbol) -> Result<Self::T, Self::E> {
+        Ok(SExpr::Symbol(value))
+    }
+
+    fn visit_keyword_s_expr(&mut self, value: Keyword) -> Result<Self::T, Self::E> {
+        Ok(SExpr::Keyword(value))
+    }
+
+    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Result<Self::T, Self::E> {
+        Ok(SExpr::Application(values))
+    }
+}
+
+impl SExpr {
+    /// Visit a concrete S-expression.
+    pub fn accept<V, T, C, S, K, E>(self, visitor: &mut V) -> Result<T, E>
+    where
+        V: SExprVisitor<C, S, K, T = T, E = E>
+            + ConstantVisitor<T = C, E = E>
+            + SymbolVisitor<T = S, E = E>
+            + KeywordVisitor<T = K, E = E>,
+    {
+        use SExpr::*;
+        match self {
+            Constant(value) => {
+                let c = value.accept(visitor)?;
+                visitor.visit_constant_s_expr(c)
+            }
+            Symbol(value) => {
+                let s = visitor.visit_bound_symbol(value.0)?;
+                visitor.visit_symbol_s_expr(s)
+            }
+            Keyword(value) => {
+                let k = value.accept(visitor)?;
+                visitor.visit_keyword_s_expr(k)
+            }
+            Application(values) => {
+                let ts = values
+                    .into_iter()
+                    .map(|e| e.accept(visitor))
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_application_s_expr(ts)
+            }
+        }
+    }
+}
+
+impl<Symbol> SortVisitor<Symbol> for SyntaxBuilder {
+    type T = Sort<Identifier<Symbol>>;
+    type E = Error;
+
+    fn visit_simple_sort(&mut self, identifier: Identifier<Symbol>) -> Result<Self::T, Self::E> {
+        Ok(Sort::Simple { identifier })
+    }
+
+    fn visit_parameterized_sort(
+        &mut self,
+        identifier: Identifier<Symbol>,
+        parameters: Vec<Self::T>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Sort::Parameterized {
+            identifier,
+            parameters,
+        })
+    }
+}
+
+impl Sort {
+    /// Visit a concrete sort.
+    pub fn accept<V, T, S, E>(self, visitor: &mut V) -> Result<T, E>
+    where
+        V: SortVisitor<S, T = T, E = E> + SymbolVisitor<T = S, E = E>,
+    {
+        use Sort::*;
+        match self {
+            Simple { identifier } => {
+                let i = identifier.remap(visitor, |v, s: Symbol| v.visit_bound_symbol(s.0))?;
+                visitor.visit_simple_sort(i)
+            }
+            Parameterized {
+                identifier,
+                parameters,
+            } => {
+                let i = identifier.remap(visitor, |v, s: Symbol| v.visit_bound_symbol(s.0))?;
+                let ts = parameters
+                    .into_iter()
+                    .map(|s| s.accept(visitor))
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_parameterized_sort(i, ts)
+            }
+        }
+    }
+}
+
+impl<Identifier, Sort> QualIdentifierVisitor<Identifier, Sort> for SyntaxBuilder {
+    type T = QualIdentifier<Identifier, Sort>;
+    type E = Error;
+
+    fn visit_simple_identifier(&mut self, identifier: Identifier) -> Result<Self::T, Self::E> {
+        Ok(QualIdentifier::Simple { identifier })
+    }
+
+    fn visit_sorted_identifier(
+        &mut self,
+        identifier: Identifier,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E> {
+        Ok(QualIdentifier::Sorted { identifier, sort })
+    }
+}
+
+impl QualIdentifier {
+    /// Visit a concrete qualified identifier.
+    pub fn accept<V, T, E, S1, S2>(self, visitor: &mut V) -> Result<T, E>
+    where
+        V: SortVisitor<S1, T = S2, E = E>
+            + SymbolVisitor<T = S1, E = E>
+            + QualIdentifierVisitor<Identifier<S1>, S2, T = T, E = E>,
+    {
+        use QualIdentifier::*;
+        match self {
+            Simple { identifier } => {
+                let i = identifier.remap(visitor, |v, s: Symbol| v.visit_bound_symbol(s.0))?;
+                visitor.visit_simple_identifier(i)
+            }
+            Sorted { identifier, sort } => {
+                let i = identifier.remap(visitor, |v, s: Symbol| v.visit_bound_symbol(s.0))?;
+                let s = sort.accept(visitor)?;
+                visitor.visit_sorted_identifier(i, s)
+            }
+        }
+    }
+}
+
+impl<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort>
+    TermVisitor<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort> for SyntaxBuilder
+{
+    type T = Term<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort>;
+    type E = Error;
+
+    fn visit_constant(&mut self, constant: Constant) -> Result<Self::T, Self::E> {
+        Ok(Term::Constant(constant))
+    }
+
+    fn visit_qual_identifier(
+        &mut self,
+        qual_identifier: QualIdentifier,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Term::QualIdentifier(qual_identifier))
+    }
+
+    fn visit_application(
+        &mut self,
+        qual_identifier: QualIdentifier,
+        arguments: Vec<Self::T>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Term::Application {
+            qual_identifier,
+            arguments,
+        })
+    }
+
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(Symbol, Self::T)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
+        let term = Box::new(term);
+        Ok(Term::Let { var_bindings, term })
+    }
+
+    fn visit_forall(
+        &mut self,
+        vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
+        let term = Box::new(term);
+        Ok(Term::Forall { vars, term })
+    }
+
+    fn visit_exists(
+        &mut self,
+        vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
+        let term = Box::new(term);
+        Ok(Term::Exists { vars, term })
+    }
+
+    fn visit_match(
+        &mut self,
+        term: Self::T,
+        cases: Vec<(Vec<Symbol>, Self::T)>,
+    ) -> Result<Self::T, Self::E> {
+        let term = Box::new(term);
+        Ok(Term::Match { term, cases })
+    }
+
+    fn visit_attributes(
+        &mut self,
+        term: Self::T,
+        attributes: Vec<(Keyword, AttributeValue<Constant, Symbol, SExpr>)>,
+    ) -> Result<Self::T, Self::E> {
+        let term = Box::new(term);
+        Ok(Term::Attributes { term, attributes })
+    }
+}
+
+impl Term {
+    /// Visit a concrete term.
+    pub fn accept<V, T, E, S1, S2, S3, S4, S5, S6>(self, visitor: &mut V) -> Result<T, E>
+    where
+        V: SortVisitor<S1, T = S2, E = E>
+            + SymbolVisitor<T = S1, E = E>
+            + QualIdentifierVisitor<Identifier<S1>, S2, T = S3, E = E>
+            + ConstantVisitor<T = S4, E = E>
+            + KeywordVisitor<T = S5, E = E>
+            + SExprVisitor<S4, S1, S5, T = S6, E = E>
+            + TermVisitor<S4, S3, S5, S6, S1, S2, T = T, E = E>,
+    {
+        use Term::*;
+        match self {
+            Constant(value) => {
+                let c = value.accept(visitor)?;
+                visitor.visit_constant(c)
+            }
+            QualIdentifier(value) => {
+                let qi = value.accept(visitor)?;
+                visitor.visit_qual_identifier(qi)
+            }
+            Application {
+                qual_identifier,
+                arguments,
+            } => {
+                let qi = qual_identifier.accept(visitor)?;
+                let mut ts = Vec::new();
+                for t in arguments {
+                    ts.push(t.accept(visitor)?);
+                }
+                visitor.visit_application(qi, ts)
+            }
+            Let { var_bindings, term } => {
+                let bs = var_bindings
+                    .into_iter()
+                    .map(|(s, t)| {
+                        Ok((
+                            visitor.visit_fresh_symbol(s.0, SymbolKind::Variable)?,
+                            t.accept(visitor)?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, E>>()?;
+                bs.iter().for_each(|(s, _)| visitor.bind_symbol(s));
+                let t = term.accept(visitor)?;
+                bs.iter().for_each(|(s, _)| visitor.unbind_symbol(s));
+                visitor.visit_let(bs, t)
+            }
+            Forall { vars, term } => {
+                let vs = vars
+                    .into_iter()
+                    .map(|(v, s)| {
+                        Ok((
+                            visitor.visit_fresh_symbol(v.0, SymbolKind::Variable)?,
+                            s.accept(visitor)?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, E>>()?;
+                vs.iter().for_each(|(s, _)| visitor.bind_symbol(s));
+                let t = term.accept(visitor)?;
+                vs.iter().for_each(|(s, _)| visitor.unbind_symbol(s));
+                visitor.visit_forall(vs, t)
+            }
+            Exists { vars, term } => {
+                let vs = vars
+                    .into_iter()
+                    .map(|(v, s)| {
+                        Ok((
+                            visitor.visit_fresh_symbol(v.0, SymbolKind::Variable)?,
+                            s.accept(visitor)?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, E>>()?;
+                vs.iter().for_each(|(s, _)| visitor.bind_symbol(s));
+                let t = term.accept(visitor)?;
+                vs.iter().for_each(|(s, _)| visitor.unbind_symbol(s));
+                visitor.visit_exists(vs, t)
+            }
+            Match { term, cases } => {
+                let t = term.accept(visitor)?;
+                let cs = cases
+                    .into_iter()
+                    .map(|(ss, t)| {
+                        let mut symbols = Vec::new();
+                        let mut ss = ss.into_iter();
+                        let mut has_fresh_first_symbol = false;
+                        if let Some(s) = ss.next() {
+                            // First symbol may be a constructor.
+                            symbols.push(visitor.visit_bound_symbol(s.0.clone()).or_else(
+                                |_| {
+                                    has_fresh_first_symbol = true;
+                                    let s = visitor
+                                        .visit_fresh_symbol(s.0.clone(), SymbolKind::Variable)?;
+                                    visitor.bind_symbol(&s);
+                                    Ok(s)
+                                },
+                            )?);
+                        }
+                        for s in ss {
+                            let s = visitor.visit_fresh_symbol(s.0, SymbolKind::Variable)?;
+                            visitor.bind_symbol(&s);
+                            symbols.push(s);
+                        }
+                        let term = t.accept(visitor)?;
+                        let mut ss = symbols.iter();
+                        if let Some(s) = ss.next() {
+                            if has_fresh_first_symbol {
+                                visitor.unbind_symbol(s);
+                            }
+                        }
+                        for s in ss {
+                            visitor.unbind_symbol(s);
+                        }
+                        Ok((symbols, term))
+                    })
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_match(t, cs)
+            }
+            Attributes { term, attributes } => {
+                let t = term.accept(visitor)?;
+                let xs = attributes
+                    .into_iter()
+                    .map(|(k, x)| {
+                        Ok((
+                            k.accept(visitor)?,
+                            x.remap(
+                                visitor,
+                                |v, c: self::Constant| c.accept(v),
+                                |v, s: Symbol| v.visit_bound_symbol(s.0),
+                                |v, e: SExpr| e.accept(v),
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_attributes(t, xs)
+            }
+        }
+    }
+}
+
+impl<Term, Symbol, Sort, Keyword, Constant, SExpr>
+    CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> for SyntaxBuilder
+{
+    type T = Command<Term, Symbol, Sort, Keyword, Constant, SExpr>;
+    type E = Error;
+
+    fn visit_assert(&mut self, term: Term) -> Result<Self::T, Self::E> {
+        Ok(Command::Assert { term })
+    }
+
+    fn visit_check_sat(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::CheckSat)
+    }
+
+    fn visit_check_sat_assuming(
+        &mut self,
+        literals: Vec<(Symbol, bool)>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::CheckSatAssuming { literals })
+    }
+
+    fn visit_declare_const(&mut self, symbol: Symbol, sort: Sort) -> Result<Self::T, Self::E> {
+        Ok(Command::DeclareConst { symbol, sort })
+    }
+
+    fn visit_declare_datatype(
+        &mut self,
+        symbol: Symbol,
+        datatype: DatatypeDec<Symbol, Sort>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DeclareDatatype { symbol, datatype })
+    }
+
+    fn visit_declare_datatypes(
+        &mut self,
+        datatypes: Vec<(Symbol, Numeral, DatatypeDec<Symbol, Sort>)>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DeclareDatatypes { datatypes })
+    }
+
+    fn visit_declare_fun(
+        &mut self,
+        symbol: Symbol,
+        parameters: Vec<Sort>,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DeclareFun {
+            symbol,
+            parameters,
+            sort,
+        })
+    }
+
+    fn visit_declare_sort(&mut self, symbol: Symbol, arity: Numeral) -> Result<Self::T, Self::E> {
+        Ok(Command::DeclareSort { symbol, arity })
+    }
+
+    fn visit_define_fun(
+        &mut self,
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DefineFun { sig, term })
+    }
+
+    fn visit_define_fun_rec(
+        &mut self,
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DefineFunRec { sig, term })
+    }
+
+    fn visit_define_funs_rec(
+        &mut self,
+        funs: Vec<(FunctionDec<Symbol, Sort>, Term)>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DefineFunsRec { funs })
+    }
+
+    fn visit_define_sort(
+        &mut self,
+        symbol: Symbol,
+        parameters: Vec<Symbol>,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::DefineSort {
+            symbol,
+            parameters,
+            sort,
+        })
+    }
+
+    fn visit_echo(&mut self, message: String) -> Result<Self::T, Self::E> {
+        Ok(Command::Echo { message })
+    }
+
+    fn visit_exit(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::Exit)
+    }
+
+    fn visit_get_assertions(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::GetAssertions)
+    }
+
+    fn visit_get_assignment(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::GetAssignment)
+    }
+
+    fn visit_get_info(&mut self, flag: Keyword) -> Result<Self::T, Self::E> {
+        Ok(Command::GetInfo { flag })
+    }
+
+    fn visit_get_model(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::GetModel)
+    }
+
+    fn visit_get_option(&mut self, keyword: Keyword) -> Result<Self::T, Self::E> {
+        Ok(Command::GetOption { keyword })
+    }
+
+    fn visit_get_proof(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::GetProof)
+    }
+
+    fn visit_get_unsat_assumptions(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::GetUnsatAssumptions)
+    }
+
+    fn visit_get_unsat_core(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::GetUnsatCore)
+    }
+
+    fn visit_get_value(&mut self, terms: Vec<Term>) -> Result<Self::T, Self::E> {
+        Ok(Command::GetValue { terms })
+    }
+
+    fn visit_pop(&mut self, level: Numeral) -> Result<Self::T, Self::E> {
+        Ok(Command::Pop { level })
+    }
+
+    fn visit_push(&mut self, level: Numeral) -> Result<Self::T, Self::E> {
+        Ok(Command::Push { level })
+    }
+
+    fn visit_reset(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::Reset)
+    }
+
+    fn visit_reset_assertions(&mut self) -> Result<Self::T, Self::E> {
+        Ok(Command::ResetAssertions)
+    }
+
+    fn visit_set_info(
+        &mut self,
+        keyword: Keyword,
+        value: AttributeValue<Constant, Symbol, SExpr>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::SetInfo { keyword, value })
+    }
+
+    fn visit_set_logic(&mut self, symbol: Symbol) -> Result<Self::T, Self::E> {
+        Ok(Command::SetLogic { symbol })
+    }
+
+    fn visit_set_option(
+        &mut self,
+        keyword: Keyword,
+        value: AttributeValue<Constant, Symbol, SExpr>,
+    ) -> Result<Self::T, Self::E> {
+        Ok(Command::SetOption { keyword, value })
+    }
+}
+
+impl Command {
+    /// Visit a concrete command.
+    pub fn accept<V, T, E, S1, S2, S3, S4, S5, S6, S7>(self, visitor: &mut V) -> Result<T, E>
+    where
+        V: SortVisitor<S1, T = S2, E = E>
+            + SymbolVisitor<T = S1, E = E>
+            + QualIdentifierVisitor<Identifier<S1>, S2, T = S3, E = E>
+            + ConstantVisitor<T = S4, E = E>
+            + KeywordVisitor<T = S5, E = E>
+            + SExprVisitor<S4, S1, S5, T = S6, E = E>
+            + TermVisitor<S4, S3, S5, S6, S1, S2, T = S7, E = E>
+            + CommandVisitor<S7, S1, S2, S5, S4, S6, T = T, E = E>,
+    {
+        use Command::*;
+        match self {
+            Assert { term } => {
+                let t = term.accept(visitor)?;
+                visitor.visit_assert(t)
+            }
+            CheckSat => visitor.visit_check_sat(),
+            CheckSatAssuming { literals } => {
+                let ls = literals
+                    .into_iter()
+                    .map(|(s, b)| Ok((visitor.visit_bound_symbol(s.0)?, b)))
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_check_sat_assuming(ls)
+            }
+            DeclareConst { symbol, sort } => {
+                let symb = visitor.visit_fresh_symbol(symbol.0, SymbolKind::Constant)?;
+                let sort = sort.accept(visitor)?;
+                visitor.bind_symbol(&symb);
+                visitor.visit_declare_const(symb, sort)
+            }
+            DeclareDatatype { symbol, datatype } => {
+                let s = visitor.visit_fresh_symbol(symbol.0, SymbolKind::Datatype)?;
+                // Datatype may be recursive, so we bind the name early.
+                visitor.bind_symbol(&s);
+                let dt = datatype.remap(
+                    visitor,
+                    |_, _| panic!("unexpected type parameters in DeclareDatatype"),
+                    |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Constructor),
+                    |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Selector),
+                    |v, sort| sort.accept(v),
+                )?;
+                // Bind constructor symbols and selectors.
+                dt.constructors.iter().for_each(|c| {
+                    visitor.bind_symbol(&c.symbol);
+                    c.selectors.iter().for_each(|(s, _)| visitor.bind_symbol(s));
+                });
+                visitor.visit_declare_datatype(s, dt)
+            }
+            DeclareDatatypes { datatypes } => {
+                let dts = datatypes
+                    .into_iter()
+                    .map(|(s, n, dt)| {
+                        let s = visitor.visit_fresh_symbol(s.0, SymbolKind::Datatype)?;
+                        // Datatype may be recursive, so we bind the names early.
+                        visitor.bind_symbol(&s);
+                        Ok((s, n, dt))
+                    })
+                    .collect::<Result<Vec<_>, E>>()?;
+                let dts = dts
+                    .into_iter()
+                    .map(|(s, n, dt)| {
+                        let dt = dt.remap(
+                            visitor,
+                            |v, s| {
+                                // Bind type parameters before visiting sorts.
+                                let s = v.visit_fresh_symbol(s.0, SymbolKind::TypeVar)?;
+                                v.bind_symbol(&s);
+                                Ok(s)
+                            },
+                            |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Constructor),
+                            |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Selector),
+                            |v, sort| sort.accept(v),
+                        )?;
+                        // Unbind type parameters.
+                        dt.parameters.iter().for_each(|s| visitor.unbind_symbol(s));
+                        // Bind constructor symbols and selectors.
+                        dt.constructors.iter().for_each(|c| {
+                            visitor.bind_symbol(&c.symbol);
+                            c.selectors.iter().for_each(|(s, _)| visitor.bind_symbol(s));
+                        });
+                        Ok((s, n, dt))
+                    })
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_declare_datatypes(dts)
+            }
+            DeclareFun {
+                symbol,
+                parameters,
+                sort,
+            } => {
+                let symb = visitor.visit_fresh_symbol(symbol.0, SymbolKind::Function)?;
+                let ps = parameters
+                    .into_iter()
+                    .map(|s| s.accept(visitor))
+                    .collect::<Result<_, E>>()?;
+                let sort = sort.accept(visitor)?;
+                visitor.bind_symbol(&symb);
+                visitor.visit_declare_fun(symb, ps, sort)
+            }
+            DeclareSort { symbol, arity } => {
+                let s = visitor.visit_fresh_symbol(symbol.0, SymbolKind::Sort)?;
+                visitor.bind_symbol(&s);
+                visitor.visit_declare_sort(s, arity)
+            }
+            DefineFun { sig, term } => {
+                let sig = sig.remap(
+                    visitor,
+                    |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Function),
+                    |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Variable),
+                    |v, s| s.accept(v),
+                )?;
+                sig.parameters
+                    .iter()
+                    .for_each(|(s, _)| visitor.bind_symbol(s));
+                let t = term.accept(visitor)?;
+                sig.parameters
+                    .iter()
+                    .for_each(|(s, _)| visitor.unbind_symbol(s));
+                visitor.bind_symbol(&sig.name);
+                visitor.visit_define_fun(sig, t)
+            }
+            DefineFunRec { sig, term } => {
+                let sig = sig.remap(
+                    visitor,
+                    |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Function),
+                    |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Variable),
+                    |v, s| s.accept(v),
+                )?;
+                visitor.bind_symbol(&sig.name);
+                sig.parameters
+                    .iter()
+                    .for_each(|(s, _)| visitor.bind_symbol(s));
+                let t = term.accept(visitor)?;
+                sig.parameters
+                    .iter()
+                    .for_each(|(s, _)| visitor.unbind_symbol(s));
+                visitor.visit_define_fun_rec(sig, t)
+            }
+            DefineFunsRec { funs } => {
+                let funs = funs
+                    .into_iter()
+                    .map(|(sig, t)| {
+                        let sig = sig.remap(
+                            visitor,
+                            |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Function),
+                            |v, s| v.visit_fresh_symbol(s.0, SymbolKind::Variable),
+                            |v, s| s.accept(v),
+                        )?;
+                        visitor.bind_symbol(&sig.name);
+                        sig.parameters
+                            .iter()
+                            .for_each(|(s, _)| visitor.bind_symbol(s));
+                        Ok((sig, t))
+                    })
+                    .collect::<Result<Vec<_>, E>>()?;
+                let funs = funs
+                    .into_iter()
+                    .map(|(sig, t)| {
+                        let t = t.accept(visitor)?;
+                        sig.parameters
+                            .iter()
+                            .for_each(|(s, _)| visitor.unbind_symbol(s));
+                        Ok((sig, t))
+                    })
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_define_funs_rec(funs)
+            }
+            DefineSort {
+                symbol,
+                parameters,
+                sort,
+            } => {
+                let symbol = visitor.visit_fresh_symbol(symbol.0, SymbolKind::Sort)?;
+                let ps = parameters
+                    .into_iter()
+                    .map(|s| visitor.visit_fresh_symbol(s.0, SymbolKind::TypeVar))
+                    .collect::<Result<Vec<_>, E>>()?;
+                ps.iter().for_each(|s| visitor.bind_symbol(s));
+                let sort = sort.accept(visitor)?;
+                ps.iter().for_each(|s| visitor.unbind_symbol(s));
+                visitor.bind_symbol(&symbol);
+                visitor.visit_define_sort(symbol, ps, sort)
+            }
+            Echo { message } => visitor.visit_echo(message),
+            Exit => visitor.visit_exit(),
+            GetAssertions => visitor.visit_get_assertions(),
+            GetAssignment => visitor.visit_get_assignment(),
+            GetInfo { flag } => {
+                let k = flag.accept(visitor)?;
+                visitor.visit_get_info(k)
+            }
+            GetModel => visitor.visit_get_model(),
+            GetOption { keyword } => {
+                let k = keyword.accept(visitor)?;
+                visitor.visit_get_option(k)
+            }
+            GetProof => visitor.visit_get_proof(),
+            GetUnsatAssumptions => visitor.visit_get_unsat_assumptions(),
+            GetUnsatCore => visitor.visit_get_unsat_core(),
+            GetValue { terms } => {
+                let ts = terms
+                    .into_iter()
+                    .map(|t| t.accept(visitor))
+                    .collect::<Result<_, E>>()?;
+                visitor.visit_get_value(ts)
+            }
+            Pop { level } => visitor.visit_pop(level),
+            Push { level } => visitor.visit_push(level),
+            Reset => visitor.visit_reset(),
+            ResetAssertions => visitor.visit_reset_assertions(),
+            SetInfo { keyword, value } => {
+                let k = keyword.accept(visitor)?;
+                let v = value.remap(
+                    visitor,
+                    |v, c: self::Constant| c.accept(v),
+                    |v, s: Symbol| v.visit_bound_symbol(s.0),
+                    |v, e: SExpr| e.accept(v),
+                )?;
+                visitor.visit_set_info(k, v)
+            }
+            SetLogic { symbol } => {
+                let s = visitor.visit_bound_symbol(symbol.0)?;
+                visitor.visit_set_logic(s)
+            }
+            SetOption { keyword, value } => {
+                let k = keyword.accept(visitor)?;
+                let v = value.remap(
+                    visitor,
+                    |v, c: self::Constant| c.accept(v),
+                    |v, s: Symbol| v.visit_bound_symbol(s.0),
+                    |v, e: SExpr| e.accept(v),
+                )?;
+                visitor.visit_set_option(k, v)
+            }
+        }
+    }
+}
+
+impl Smt2Visitor for SyntaxBuilder {
+    type Error = Error;
+    type Constant = Constant;
+    type QualIdentifier = QualIdentifier;
+    type Keyword = Keyword;
+    type Sort = Sort;
+    type SExpr = SExpr;
+    type Symbol = Symbol;
+    type Term = Term;
+    type Command = Command;
+
+    fn syntax_error(&mut self, position: crate::smt2parser::Position, s: String) -> Self::Error {
+        Error::SyntaxError(position, s)
+    }
+
+    fn parsing_error(&mut self, position: crate::smt2parser::Position, s: String) -> Self::Error {
+        Error::ParsingError(position, s)
+    }
+}
+
+impl std::fmt::Display for Constant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨numeral⟩ | ⟨decimal⟩ | ⟨hexadecimal⟩ | ⟨binary⟩ | ⟨string⟩
+        use Constant::*;
+        match self {
+            Numeral(num) => write!(f, "{}", num),
+            Decimal(dec) => {
+                let nom = dec.trunc();
+                let mut denom = dec.fract();
+                while !denom.is_integer() {
+                    denom *= num::BigInt::from(10u32);
+                }
+                write!(f, "{}.{}", nom, denom)
+            }
+            Hexadecimal(hex) => {
+                write!(f, "#x")?;
+                for digit in hex {
+                    write!(f, "{:x}", digit)?;
+                }
+                Ok(())
+            }
+            Binary(bin) => {
+                write!(f, "#b")?;
+                for digit in bin {
+                    if *digit {
+                        write!(f, "1")?;
+                    } else {
+                        write!(f, "0")?;
+                    }
+                }
+                Ok(())
+            }
+            String(value) => {
+                for s in value.split('"') {
+                    write!(f, "\"{}\"", s)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Symbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let c = self.0.as_bytes().get(0);
+        if c.is_some()
+            && lexer::is_non_digit_symbol_byte(*c.unwrap())
+            && self.0.as_bytes().iter().all(|c| lexer::is_symbol_byte(*c))
+        {
+            write!(f, "{}", self.0)
+        } else {
+            write!(f, "|{}|", self.0)
+        }
+    }
+}
+
+impl std::fmt::Display for Keyword {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, ":{}", self.0)
+    }
+}
+
+impl<Constant, Symbol, Keyword> std::fmt::Display for SExpr<Constant, Symbol, Keyword>
+where
+    Constant: std::fmt::Display,
+    Symbol: std::fmt::Display,
+    Keyword: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨spec_constant⟩ | ⟨symbol⟩ | ⟨keyword⟩ | ( ⟨s_expr⟩∗ )
+        use SExpr::*;
+        match self {
+            Constant(c) => write!(f, "{}", c),
+            Symbol(s) => write!(f, "{}", s),
+            Keyword(k) => write!(f, "{}", k),
+            Application(values) => write!(f, "({})", values.iter().format(" ")),
+        }
+    }
+}
+
+impl<Identifier> std::fmt::Display for Sort<Identifier>
+where
+    Identifier: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨identifier⟩ | ( ⟨identifier⟩ ⟨sort⟩+ )
+        use Sort::*;
+        match self {
+            Simple { identifier } => write!(f, "{}", identifier),
+            Parameterized {
+                identifier,
+                parameters,
+            } => write!(f, "({} {})", identifier, parameters.iter().format(" ")),
+        }
+    }
+}
+
+impl<Identifier> std::fmt::Display for QualIdentifier<Identifier>
+where
+    Identifier: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨identifier⟩ | ( as ⟨identifier⟩ ⟨sort⟩ )
+        use QualIdentifier::*;
+        match self {
+            Simple { identifier } => write!(f, "{}", identifier),
+            Sorted { identifier, sort } => write!(f, "(as {} {})", identifier, sort),
+        }
+    }
+}
+
+impl<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort> std::fmt::Display
+    for Term<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort>
+where
+    Constant: std::fmt::Display,
+    QualIdentifier: std::fmt::Display,
+    Keyword: std::fmt::Display,
+    SExpr: std::fmt::Display,
+    Symbol: std::fmt::Display,
+    Sort: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Term::*;
+        match self {
+            Constant(c) => {
+                // ⟨spec_constant⟩
+                write!(f, "{}", c)
+            }
+            QualIdentifier(id) => {
+                // ⟨qual_identifier⟩
+                write!(f, "{}", id)
+            }
+            Application {
+                qual_identifier,
+                arguments,
+            } => {
+                // ( ⟨qual_identifier ⟩ ⟨term⟩+ )
+                write!(f, "({} {})", qual_identifier, arguments.iter().format(" "))
+            }
+            Let { var_bindings, term } => {
+                // ( let ( ⟨var_binding⟩+ ) ⟨term⟩ )
+                write!(
+                    f,
+                    "(let ({}) {})",
+                    var_bindings
+                        .iter()
+                        .format_with(" ", |(v, t), f| f(&format_args!("({} {})", v, t))),
+                    term
+                )
+            }
+            Forall { vars, term } => {
+                // ( forall ( ⟨sorted_var⟩+ ) ⟨term⟩ )
+                write!(
+                    f,
+                    "(forall ({}) {})",
+                    vars.iter()
+                        .format_with(" ", |(v, s), f| f(&format_args!("({} {})", v, s))),
+                    term
+                )
+            }
+            Exists { vars, term } => {
+                // ( exists ( ⟨sorted_var⟩+ ) ⟨term⟩ )
+                write!(
+                    f,
+                    "(exists ({}) {})",
+                    vars.iter()
+                        .format_with(" ", |(v, s), f| f(&format_args!("({} {})", v, s))),
+                    term
+                )
+            }
+            Match { term, cases } => {
+                // ( match ⟨term⟩ ( ⟨match_case⟩+ ) )
+                write!(
+                    f,
+                    "(match {} ({}))",
+                    term,
+                    cases.iter().format_with(" ", |(pattern, term), f| {
+                        if pattern.len() == 1 {
+                            f(&format_args!("({} {})", &pattern[0], term))
+                        } else {
+                            f(&format_args!("(({}) {})", pattern.iter().format(" "), term))
+                        }
+                    })
+                )
+            }
+            Attributes { term, attributes } => {
+                // ( ! ⟨term⟩ ⟨attribute⟩+ )
+                write!(
+                    f,
+                    "(! {} {})",
+                    term,
+                    attributes
+                        .iter()
+                        .format_with(" ", |(key, value), f| match value {
+                            AttributeValue::None => f(key),
+                            _ => f(&format_args!("{} {}", key, value)),
+                        })
+                )
+            }
+        }
+    }
+}
+
+impl<Term, Symbol, Sort, Keyword, Constant, SExpr> std::fmt::Display
+    for Command<Term, Symbol, Sort, Keyword, Constant, SExpr>
+where
+    Term: std::fmt::Display,
+    Symbol: std::fmt::Display,
+    Sort: std::fmt::Display,
+    Keyword: std::fmt::Display,
+    Constant: std::fmt::Display,
+    SExpr: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Command::*;
+        match self {
+            Assert { term } => write!(f, "(assert {})", term),
+            CheckSat => write!(f, "(check-sat)"),
+            CheckSatAssuming { literals } => {
+                // ( check-sat-assuming ( ⟨prop_literal⟩∗ ) )
+                write!(
+                    f,
+                    "(check-sat-assuming ({}))",
+                    literals.iter().format_with(" ", |(s, b), f| {
+                        // ⟨symbol⟩ | ( not ⟨symbol⟩ )
+                        if *b {
+                            f(s)
+                        } else {
+                            f(&format_args!("(not {})", s))
+                        }
+                    })
+                )
+            }
+            DeclareConst { symbol, sort } => write!(f, "(declare-const {} {})", symbol, sort),
+            DeclareDatatype { symbol, datatype } => {
+                write!(f, "(declare-datatype {} {})", symbol, datatype)
+            }
+            DeclareDatatypes { datatypes } => {
+                // ( declare-datatypes ( ⟨sort_dec⟩n+1 ) ( ⟨datatype_dec⟩n+1 ) )
+                let sorts = datatypes.iter().format_with(" ", |(sym, num, _), f| {
+                    f(&format_args!("({} {})", sym, num))
+                });
+                let types = datatypes.iter().format_with(" ", |(_, _, ty), f| f(ty));
+                write!(f, "(declare-datatypes ({}) ({}))", sorts, types)
+            }
+            DeclareFun {
+                symbol,
+                parameters,
+                sort,
+            } => {
+                // ( declare-fun ⟨symbol⟩ ( ⟨sort⟩∗ ) ⟨sort⟩ )
+                write!(
+                    f,
+                    "(declare-fun {} ({}) {})",
+                    symbol,
+                    parameters.iter().format(" "),
+                    sort
+                )
+            }
+            DeclareSort { symbol, arity } => write!(
+                f,
+                "(declare-sort {} {})",
+                symbol,
+                self::Constant::Numeral(arity.clone())
+            ),
+            DefineFun { sig, term } => {
+                // ( define-fun ⟨function_dec⟩ ⟨term⟩ )
+                write!(f, "(define-fun {} {})", sig, term)
+            }
+            DefineFunRec { sig, term } => {
+                // ( define-fun-rec ⟨function_dec⟩ ⟨term⟩ )
+                write!(f, "(define-fun {} {})", sig, term)
+            }
+            DefineFunsRec { funs } => {
+                // ( define-funs-rec ( ( ⟨function_dec⟩ )n+1 ) ( ⟨term⟩n+1 ) )
+                let sigs = funs.iter().format_with(" ", |(sig, _), f| f(sig));
+                let terms = funs.iter().format_with(" ", |(_, t), f| f(t));
+                write!(f, "(define-funs-rec ({}) ({}))", sigs, terms)
+            }
+            DefineSort {
+                symbol,
+                parameters,
+                sort,
+            } => {
+                // ( define-sort ⟨symbol⟩ ( ⟨symbol⟩∗ ) ⟨sort⟩ )
+                write!(
+                    f,
+                    "(define-sort {} ({}) {})",
+                    symbol,
+                    parameters.iter().format(" "),
+                    sort
+                )
+            }
+            Echo { message } => write!(f, "(echo {})", self::Constant::String(message.clone())),
+            Exit => write!(f, "(exit)"),
+            GetAssertions => write!(f, "(get-assertions)"),
+            GetAssignment => write!(f, "(get-assignment)"),
+            GetInfo { flag } => write!(f, "(get-info {})", flag),
+            GetModel => write!(f, "(get-model)"),
+            GetOption { keyword } => write!(f, "(get-info {})", keyword),
+            GetProof => write!(f, "(get-proof)"),
+            GetUnsatAssumptions => write!(f, "(get-unsat-assumptions)"),
+            GetUnsatCore => write!(f, "(get-unsat-core)"),
+            GetValue { terms } => {
+                // ( get-value ( ⟨term⟩+ ) )
+                write!(f, "(get-value ({}))", terms.iter().format(" "))
+            }
+            Pop { level } => write!(f, "(pop {})", self::Constant::Numeral(level.clone())),
+            Push { level } => write!(f, "(push {})", self::Constant::Numeral(level.clone())),
+            Reset => write!(f, "(reset)"),
+            ResetAssertions => write!(f, "(reset-assertions)"),
+            SetInfo { keyword, value } => write!(f, "(set-info {} {})", keyword, value),
+            SetLogic { symbol } => write!(f, "(set-logic {})", symbol),
+            SetOption { keyword, value } => write!(f, "(set-option {} {})", keyword, value),
+        }
+    }
+}
+
+/// Parse a single-token attribute value.
+pub fn parse_simple_attribute_value(input: &str) -> Option<AttributeValue> {
+    use crate::smt2parser::parser::Token;
+    let token = lexer::Lexer::new(input.as_bytes()).next()?;
+    match token {
+        Token::Numeral(x) => Some(AttributeValue::Constant(Constant::Numeral(x))),
+        Token::Decimal(x) => Some(AttributeValue::Constant(Constant::Decimal(x))),
+        Token::String(x) => Some(AttributeValue::Constant(Constant::String(x))),
+        Token::Binary(x) => Some(AttributeValue::Constant(Constant::Binary(x))),
+        Token::Hexadecimal(x) => Some(AttributeValue::Constant(Constant::Hexadecimal(x))),
+        Token::Symbol(x) => Some(AttributeValue::Symbol(Symbol(x))),
+        _ => None,
+    }
+}
+
+#[test]
+fn test_syntax_visitor() {
+    // (assert (let ((x (f x 2))) (= x 3)))
+    let command = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+    let mut builder = SyntaxBuilder::default();
+    let command2 = command.clone().accept(&mut builder).unwrap();
+    assert_eq!(command, command2);
+}

--- a/aws-smt-ir/src/smt2parser/lexer.rs
+++ b/aws-smt-ir/src/smt2parser/lexer.rs
@@ -40,7 +40,9 @@ pub(crate) struct Lexer<R> {
     current_column: usize,
 }
 
-const KEYWORDS: &[(&str, Token)] = {
+// Amazon update: changed the type of keywords (cf. parser.rs)
+#[allow(clippy::type_complexity)]
+const KEYWORDS: &[(&str, fn(String) -> Token)] = {
     use Token::*;
     &[
         ("_", Underscore),
@@ -83,6 +85,7 @@ const KEYWORDS: &[(&str, Token)] = {
         ("set-option", SetOption),
     ]
 };
+// end Amazon updates
 
 impl<R> Lexer<R>
 where
@@ -111,8 +114,8 @@ where
         let mut keywords = KEYWORDS.to_vec();
         keywords.sort_by_key(|(key, _)| key.to_string());
         let mut words = Vec::new();
-        for (_, token) in &keywords {
-            words.push(token.clone());
+        for (s, f) in &keywords {
+            words.push(f(s.to_string()))
         }
         let map = fst::Map::from_iter(
             keywords

--- a/aws-smt-ir/src/smt2parser/lexer.rs
+++ b/aws-smt-ir/src/smt2parser/lexer.rs
@@ -1,0 +1,540 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//! Lexing primitives.
+
+use crate::smt2parser::{parser::Token, Decimal, Numeral};
+use num::Num;
+
+/// Record a position in the input stream.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct Position {
+    pub path: Option<String>,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl Position {
+    pub fn new(path: Option<String>, line: usize, column: usize) -> Self {
+        Self { path, line, column }
+    }
+}
+
+impl std::fmt::Display for Position {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.path {
+            Some(path) => write!(f, "{}:{}:{}", path, self.line, self.column),
+            None => write!(f, "{}:{}", self.line, self.column),
+        }
+    }
+}
+
+pub(crate) struct Lexer<R> {
+    reader: R,
+    reserved_words: Vec<Token>,
+    reserved_words_map: fst::Map<Vec<u8>>,
+    current_offset: usize,
+    current_line: usize,
+    current_column: usize,
+}
+
+const KEYWORDS: &[(&str, Token)] = {
+    use Token::*;
+    &[
+        ("_", Underscore),
+        ("!", Exclam),
+        ("as", As),
+        ("let", Let),
+        ("exists", Exists),
+        ("forall", Forall),
+        ("match", Match),
+        ("par", Par),
+        ("assert", Assert),
+        ("check-sat", CheckSat),
+        ("check-sat-assuming", CheckSatAssuming),
+        ("declare-const", DeclareConst),
+        ("declare-datatype", DeclareDatatype),
+        ("declare-datatypes", DeclareDatatypes),
+        ("declare-fun", DeclareFun),
+        ("declare-sort", DeclareSort),
+        ("define-fun", DefineFun),
+        ("define-fun-rec", DefineFunRec),
+        ("define-funs-rec", DefineFunsRec),
+        ("define-sort", DefineSort),
+        ("echo", Echo),
+        ("exit", Exit),
+        ("get-assertions", GetAssertions),
+        ("get-assignment", GetAssignment),
+        ("get-info", GetInfo),
+        ("get-model", GetModel),
+        ("get-option", GetOption),
+        ("get-proof", GetProof),
+        ("get-unsat-assumptions", GetUnsatAssumptions),
+        ("get-unsat-core", GetUnsatCore),
+        ("get-value", GetValue),
+        ("pop", Pop),
+        ("push", Push),
+        ("reset", Reset),
+        ("reset-assertions", ResetAssertions),
+        ("set-info", SetInfo),
+        ("set-logic", SetLogic),
+        ("set-option", SetOption),
+    ]
+};
+
+impl<R> Lexer<R>
+where
+    R: std::io::BufRead,
+{
+    pub(crate) fn new(reader: R) -> Self {
+        let (reserved_words, reserved_words_map) = Self::make_reserved_words();
+        Self {
+            reader,
+            reserved_words,
+            reserved_words_map,
+            current_offset: 0,
+            current_line: 0,
+            current_column: 0,
+        }
+    }
+
+    #[inline]
+    fn lookup_symbol(&self, s: &[u8]) -> Option<&Token> {
+        self.reserved_words_map
+            .get(s)
+            .map(|index| &self.reserved_words[index as usize])
+    }
+
+    fn make_reserved_words() -> (Vec<Token>, fst::Map<Vec<u8>>) {
+        let mut keywords = KEYWORDS.to_vec();
+        keywords.sort_by_key(|(key, _)| key.to_string());
+        let mut words = Vec::new();
+        for (_, token) in &keywords {
+            words.push(token.clone());
+        }
+        let map = fst::Map::from_iter(
+            keywords
+                .iter()
+                .enumerate()
+                .map(|(index, (key, _))| (key, index as u64)),
+        )
+        .expect("Failed to create reserved token map");
+        (words, map)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_offset(&self) -> usize {
+        self.current_offset
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_column(&self) -> usize {
+        self.current_column
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_line(&self) -> usize {
+        self.current_line
+    }
+
+    #[inline]
+    pub(crate) fn update_position(&self, pos: &mut Position) {
+        pos.line = self.current_line + 1;
+        pos.column = self.current_column + 1;
+    }
+
+    fn consume_byte(&mut self) {
+        if let Some(c) = self.peek_byte() {
+            if *c == b'\n' {
+                self.current_line += 1;
+                self.current_column = 0;
+            } else {
+                self.current_column += 1;
+            }
+            self.current_offset += 1;
+            self.reader.consume(1)
+        }
+    }
+
+    fn read_byte(&mut self) -> Option<u8> {
+        let c = self.peek_byte().cloned();
+        self.consume_byte();
+        c
+    }
+
+    #[inline]
+    fn peek_bytes(&mut self) -> &[u8] {
+        self.reader
+            .fill_buf()
+            .expect("Error while reading input stream")
+    }
+
+    fn peek_byte(&mut self) -> Option<&u8> {
+        self.peek_bytes().get(0)
+    }
+
+    fn skip_whitespace(&mut self) -> bool {
+        match self.peek_byte() {
+            Some(b) if matches!(b, b' ' | b'\n' | b'\t' | b'\r') => {
+                self.consume_byte();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn skip_comment(&mut self) -> bool {
+        match self.peek_byte() {
+            Some(c) if *c == b';' => {
+                self.consume_byte();
+                while let Some(c) = self.read_byte() {
+                    if c == b'\n' {
+                        break;
+                    }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl<R> Iterator for Lexer<R>
+where
+    R: std::io::BufRead,
+{
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Token> {
+        while self.skip_whitespace() || self.skip_comment() {}
+        match self.peek_byte() {
+            // Parentheses
+            Some(b'(') => {
+                self.consume_byte();
+                Some(Token::LeftParen)
+            }
+            Some(b')') => {
+                self.consume_byte();
+                Some(Token::RightParen)
+            }
+            // Quoted symbols
+            Some(b'|') => {
+                self.consume_byte();
+                let mut content = Vec::new();
+                while let Some(c) = self.read_byte() {
+                    if c == b'|' {
+                        return match String::from_utf8(content) {
+                            Ok(s) => Some(Token::Symbol(s)),
+                            Err(_) => None,
+                        };
+                    }
+                    content.push(c);
+                }
+                // Do not accept EOI as a terminator.
+                None
+            }
+            // String literals
+            Some(b'"') => {
+                self.consume_byte();
+                let mut content = Vec::new();
+                while let Some(c) = self.read_byte() {
+                    if c == b'"' {
+                        if let Some(d) = self.peek_byte() {
+                            if *d == b'"' {
+                                self.consume_byte();
+                                content.push(b'"');
+                                continue;
+                            }
+                        }
+                        return match String::from_utf8(content) {
+                            Ok(s) => Some(Token::String(s)),
+                            Err(_) => None,
+                        };
+                    }
+                    content.push(c);
+                }
+                // Do not accept EOI as a terminator.
+                None
+            }
+            // Binary and Hexadecimal literals
+            Some(b'#') => {
+                self.consume_byte();
+                match self.peek_byte() {
+                    Some(b'b') => {
+                        self.consume_byte();
+                        let mut content = Vec::new();
+                        while let Some(c) = self.peek_byte() {
+                            match c {
+                                b'0' => content.push(false),
+                                b'1' => content.push(true),
+                                _ => break,
+                            }
+                            self.consume_byte();
+                        }
+                        if content.is_empty() {
+                            None
+                        } else {
+                            Some(Token::Binary(content))
+                        }
+                    }
+                    Some(b'x') => {
+                        self.consume_byte();
+                        let mut content = Vec::new();
+                        while let Some(c) = self.peek_byte() {
+                            match c {
+                                b'0'..=b'9' => content.push(c - b'0'),
+                                b'a'..=b'f' => content.push(c - b'a' + 10),
+                                b'A'..=b'F' => content.push(c - b'A' + 10),
+                                _ => break,
+                            }
+                            self.consume_byte();
+                        }
+                        if content.is_empty() {
+                            None
+                        } else {
+                            Some(Token::Hexadecimal(content))
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            // Number literals
+            Some(digit @ b'0'..=b'9') => {
+                let mut numerator = vec![*digit];
+                self.consume_byte();
+                while let Some(c) = self.peek_byte() {
+                    if !is_digit_byte(*c) {
+                        break;
+                    }
+                    numerator.push(*c);
+                    self.consume_byte();
+                }
+                if numerator.len() > 1 && numerator.starts_with(b"0") {
+                    return None;
+                }
+                let numerator = String::from_utf8(numerator).unwrap();
+                match self.peek_byte() {
+                    Some(b'.') => {
+                        self.consume_byte();
+                        let mut denumerator = Vec::new();
+                        while let Some(c) = self.peek_byte() {
+                            if !is_digit_byte(*c) {
+                                break;
+                            }
+                            denumerator.push(*c);
+                            self.consume_byte();
+                        }
+                        if denumerator.is_empty() {
+                            return None;
+                        }
+                        let denumerator = String::from_utf8(denumerator).unwrap();
+                        let num =
+                            num::BigInt::from_str_radix(&(numerator + &denumerator), 10).ok()?;
+                        let denom = num::BigInt::from(10u32).pow(denumerator.len() as u32);
+                        Some(Token::Decimal(Decimal::new(num, denom)))
+                    }
+                    _ => Some(Token::Numeral(
+                        Numeral::from_str_radix(&numerator, 10).ok()?,
+                    )),
+                }
+            }
+            // Keywords
+            Some(b':') => {
+                self.consume_byte();
+                let mut content = Vec::new();
+                while let Some(c) = self.peek_byte() {
+                    if !is_symbol_byte(*c) {
+                        break;
+                    }
+                    content.push(*c);
+                    self.consume_byte();
+                }
+                match String::from_utf8(content) {
+                    Ok(s) => Some(Token::Keyword(s)),
+                    Err(_) => None,
+                }
+            }
+            // Symbols (including `_` and `!`)
+            Some(c) if is_non_digit_symbol_byte(*c) => {
+                let mut content = vec![*c];
+                self.consume_byte();
+                while let Some(c) = self.peek_byte() {
+                    if !is_symbol_byte(*c) {
+                        break;
+                    }
+                    content.push(*c);
+                    self.consume_byte();
+                }
+                match self.lookup_symbol(&content) {
+                    Some(token) => Some(token.clone()),
+                    None => match String::from_utf8(content) {
+                        Ok(s) => Some(Token::Symbol(s)),
+                        Err(_) => None,
+                    },
+                }
+            }
+            // EOI or Error
+            _ => None,
+        }
+    }
+}
+
+fn is_digit_byte(c: u8) -> bool {
+    matches!(c, b'0'..=b'9')
+}
+
+pub(crate) fn is_symbol_byte(c: u8) -> bool {
+    is_digit_byte(c) || is_non_digit_symbol_byte(c)
+}
+
+pub(crate) fn is_non_digit_symbol_byte(c: u8) -> bool {
+    matches!(c,
+        b'a'..=b'z'
+        | b'A'..=b'Z'
+        | b'~'
+        | b'!'
+        | b'@'
+        | b'$'
+        | b'%'
+        | b'^'
+        | b'&'
+        | b'*'
+        | b'_'
+        | b'-'
+        | b'+'
+        | b'='
+        | b'<'
+        | b'>'
+        | b'.'
+        | b'?'
+        | b'/')
+}
+
+#[test]
+fn test_spaces() {
+    let input = b"xx  \n asd ";
+    let mut lexer = Lexer::new(&input[..]);
+    let tokens: Vec<_> = (&mut lexer).collect();
+    assert_eq!(
+        tokens,
+        vec![Token::Symbol("xx".into()), Token::Symbol("asd".into())]
+    );
+    assert_eq!(lexer.current_line(), 1);
+    assert_eq!(lexer.current_column(), 5);
+    assert_eq!(lexer.current_offset(), input.len());
+}
+
+#[test]
+fn test_error() {
+    let input = b"xx  \\";
+    let mut lexer = Lexer::new(&input[..]);
+    assert_eq!(
+        (&mut lexer).collect::<Vec<_>>(),
+        vec![Token::Symbol("xx".into())]
+    );
+    assert_eq!(lexer.current_line(), 0);
+    assert_eq!(lexer.current_column(), input.len() - 1);
+    assert_eq!(lexer.current_offset(), input.len() - 1);
+}
+
+#[test]
+fn test_literals() {
+    let lexer = Lexer::new(&b"135"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Numeral(Numeral::from(135u32))]
+    );
+
+    let lexer = Lexer::new(&b"0"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Numeral(Numeral::from(0u32))]
+    );
+
+    let lexer = Lexer::new(&b"(0 59)"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![
+            Token::LeftParen,
+            Token::Numeral(Numeral::from(0u32)),
+            Token::Numeral(Numeral::from(59u32)),
+            Token::RightParen
+        ]
+    );
+
+    let lexer = Lexer::new(&b"135"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Numeral(Numeral::from(135u32))]
+    );
+
+    let lexer = Lexer::new(&b"135.2"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Decimal(Decimal::from((
+            1352u32.into(),
+            10u32.into()
+        )))]
+    );
+
+    let mut lexer = Lexer::new(&b"0135"[..]);
+    assert!(lexer.next().is_none());
+
+    let mut lexer = Lexer::new(&b"135."[..]);
+    assert!(lexer.next().is_none());
+
+    let lexer = Lexer::new(&b"#b101"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Binary(vec![true, false, true])]
+    );
+
+    let lexer = Lexer::new(&b"#x1Ae"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Hexadecimal(vec![1, 10, 14])]
+    );
+
+    let lexer = Lexer::new(&br#""acv""12""#[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::String("acv\"12".into())]
+    );
+
+    let lexer = Lexer::new(&br#""acv12""#[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::String("acv12".into())]
+    );
+}
+
+#[test]
+fn test_symbol() {
+    let lexer = Lexer::new(&b"A$@135"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Symbol("A$@135".into())]
+    );
+
+    let lexer = Lexer::new(&b"|135|"[..]);
+    assert_eq!(lexer.collect::<Vec<_>>(), vec![Token::Symbol("135".into())]);
+}
+
+#[test]
+fn test_keyword() {
+    let lexer = Lexer::new(&b":A$@135"[..]);
+    assert_eq!(
+        lexer.collect::<Vec<_>>(),
+        vec![Token::Keyword("A$@135".into())]
+    );
+}
+
+// Amazon modifications: this test can fail depending on compiler version
+//
+// #[test]
+// fn test_token_size() {
+//     assert_eq!(std::mem::size_of::<Token>(), 72);
+//     assert_eq!(std::mem::size_of::<Box<Token>>(), 8);
+// }

--- a/aws-smt-ir/src/smt2parser/lexer.rs
+++ b/aws-smt-ir/src/smt2parser/lexer.rs
@@ -172,7 +172,7 @@ where
     }
 
     fn peek_byte(&mut self) -> Option<&u8> {
-        self.peek_bytes().get(0)
+        self.peek_bytes().first()
     }
 
     fn skip_whitespace(&mut self) -> bool {
@@ -305,7 +305,7 @@ where
                 let mut numerator = vec![*digit];
                 self.consume_byte();
                 while let Some(c) = self.peek_byte() {
-                    if !is_digit_byte(*c) {
+                    if !c.is_ascii_digit() {
                         break;
                     }
                     numerator.push(*c);
@@ -320,7 +320,7 @@ where
                         self.consume_byte();
                         let mut denumerator = Vec::new();
                         while let Some(c) = self.peek_byte() {
-                            if !is_digit_byte(*c) {
+                            if !c.is_ascii_digit() {
                                 break;
                             }
                             denumerator.push(*c);
@@ -381,12 +381,8 @@ where
     }
 }
 
-fn is_digit_byte(c: u8) -> bool {
-    matches!(c, b'0'..=b'9')
-}
-
 pub(crate) fn is_symbol_byte(c: u8) -> bool {
-    is_digit_byte(c) || is_non_digit_symbol_byte(c)
+    c.is_ascii_digit() || is_non_digit_symbol_byte(c)
 }
 
 pub(crate) fn is_non_digit_symbol_byte(c: u8) -> bool {

--- a/aws-smt-ir/src/smt2parser/parser.rs
+++ b/aws-smt-ir/src/smt2parser/parser.rs
@@ -1,0 +1,515 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#![allow(unused_braces)]
+#![allow(clippy::type_complexity)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::needless_lifetimes)]
+#![allow(clippy::let_unit_value)]
+
+pub use internal::{Parser, Token};
+
+pomelo! {
+    %module internal;
+    %include { use crate::smt2parser::visitors; }
+
+    %stack_size 0;
+
+    %parser pub struct Parser<'a, T: visitors::Smt2Visitor> {};
+    %extra_argument (&'a mut T, &'a mut crate::smt2parser::lexer::Position);
+    %error T::Error;
+    %syntax_error { match token {
+        Some(token) => Err(extra.0.syntax_error(extra.1.clone(), format!("unexpected token: {:?}", token))),
+        None => Err(extra.0.syntax_error(extra.1.clone(), "unexpected end of input".into())),
+    }};
+    %parse_fail { extra.0.parsing_error(extra.1.clone(), "unrecoverable parsing error".into()) };
+    %token #[derive(Clone, Debug, PartialEq, Eq)] pub enum Token {};
+
+    %type Keyword String;
+    %type Symbol String;
+    %type Numeral crate::smt2parser::Numeral;
+    %type Decimal crate::smt2parser::Decimal;
+    %type Hexadecimal crate::smt2parser::Hexadecimal;
+    %type Binary crate::smt2parser::Binary;
+    %type String String;
+
+    %type command T::Command;
+
+    %type term T::Term;
+    %type terms Vec<T::Term>;
+
+    %type constant T::Constant;
+    %type qual_identifier T::QualIdentifier;
+    %type identifier visitors::Identifier<T::Symbol>;
+
+    %type bound_symbol T::Symbol;
+    %type fresh_symbol T::Symbol;
+    %type fresh_symbols Vec<T::Symbol>;
+    %type any_symbol T::Symbol;
+    %type pattern_symbols Vec<T::Symbol>;
+    %type pattern Vec<T::Symbol>;
+
+    %type keyword T::Keyword;
+
+    %type sort T::Sort;
+    %type sorts Vec<T::Sort>;
+
+    %type attribute_value visitors::AttributeValue<T::Constant, T::Symbol, T::SExpr>;
+    %type attributes Vec<(T::Keyword, visitors::AttributeValue<T::Constant, T::Symbol, T::SExpr>)>;
+
+    %type s_expr T::SExpr;
+    %type s_exprs Vec<T::SExpr>;
+
+    %type index visitors::Index<T::Symbol>;
+    %type indices Vec<visitors::Index<T::Symbol>>;
+
+    %type var_binding (T::Symbol, T::Term);
+    %type var_bindings Vec<(T::Symbol, T::Term)>;
+
+    %type sorted_var (T::Symbol, T::Sort);
+    %type sorted_vars Vec<(T::Symbol, T::Sort)>;
+
+    %type match_case (Vec<T::Symbol>, T::Term);
+    %type match_cases Vec<(Vec<T::Symbol>, T::Term)>;
+
+    %type prop_literal (T::Symbol, bool);
+    %type prop_literals Vec<(T::Symbol, bool)>;
+
+    %type datatype_dec visitors::DatatypeDec<T::Symbol, T::Sort>;
+    %type datatype_decs Vec<visitors::DatatypeDec<T::Symbol, T::Sort>>;
+
+    %type selector_dec (T::Symbol, T::Sort);
+    %type selector_decs Vec<(T::Symbol, T::Sort)>;
+
+    %type constructor_dec visitors::ConstructorDec<T::Symbol, T::Sort>;
+    %type constructor_decs Vec<visitors::ConstructorDec<T::Symbol, T::Sort>>;
+
+    %type function_dec visitors::FunctionDec<T::Symbol, T::Sort>;
+    %type function_decs Vec<visitors::FunctionDec<T::Symbol, T::Sort>>;
+
+    %type sort_dec (T::Symbol, crate::smt2parser::Numeral);
+    %type sort_decs Vec<(T::Symbol, crate::smt2parser::Numeral)>;
+
+    %start_symbol command;
+
+    bound_symbol ::= Symbol(s) { extra.0.visit_bound_symbol(s)? }
+    fresh_symbol ::= Symbol(s) { extra.0.visit_fresh_symbol(s, crate::smt2parser::visitors::SymbolKind::Unknown)? }
+    any_symbol ::= Symbol(s) { extra.0.visit_any_symbol(s)? }
+    keyword ::= Keyword(s) { extra.0.visit_keyword(s)? }
+
+    fresh_symbols ::= fresh_symbol(x) { vec![x] }
+    fresh_symbols ::= fresh_symbols(mut xs) fresh_symbol(x) { xs.push(x); xs }
+    pattern_symbols ::= any_symbol(x) { vec![x] }
+    pattern_symbols ::= fresh_symbols(mut xs) fresh_symbol(x) { xs.push(x); xs }
+
+    // attribute_value ::= ⟨spec_constant⟩ | ⟨symbol⟩ | ( ⟨s_expr⟩∗ ) |
+    attribute_value ::= constant(x) { visitors::AttributeValue::Constant(x) }
+    attribute_value ::= bound_symbol(x) { visitors::AttributeValue::Symbol(x) }
+    attribute_value ::= LeftParen s_exprs?(xs) RightParen { visitors::AttributeValue::SExpr(xs.unwrap_or_else(Vec::new)) }
+    attribute_value ::= { visitors::AttributeValue::None }
+
+    attributes ::= keyword(k) attribute_value(v) { vec![(k, v)] }
+    attributes ::= attributes(mut xs) keyword(k) attribute_value(v) { xs.push((k, v)); xs }
+
+    // s_expr ::= ⟨spec_constant⟩ | ⟨symbol⟩ | ⟨keyword⟩ | ( ⟨s_expr⟩∗ )
+    s_expr ::= constant(x) { extra.0.visit_constant_s_expr(x)? }
+    s_expr ::= bound_symbol(x) { extra.0.visit_symbol_s_expr(x)? }
+    s_expr ::= keyword(x) { extra.0.visit_keyword_s_expr(x)? }
+    s_expr ::= LeftParen s_exprs?(xs) RightParen { extra.0.visit_application_s_expr(xs.unwrap_or_else(Vec::new))? }
+
+    s_exprs ::= s_expr(x) { vec![x] }
+    s_exprs ::= s_exprs(mut xs) s_expr(x) { xs.push(x); xs }
+
+    // index ::= ⟨numeral⟩ | ⟨symbol⟩
+    index ::= Numeral(x) { visitors::Index::Numeral(x) }
+    index ::= bound_symbol(x) { visitors::Index::Symbol(x) }
+
+    indices ::= index(x) { vec![x] }
+    indices ::= indices(mut xs) index(x) { xs.push(x); xs }
+
+    // identifier ::= ⟨symbol⟩ | ( _ ⟨symbol⟩ ⟨index⟩+ )
+    identifier ::= bound_symbol(symbol) { visitors::Identifier::Simple { symbol } }
+    identifier ::= LeftParen Underscore bound_symbol(symbol) indices(indices) RightParen { visitors::Identifier::Indexed { symbol, indices } }
+
+    // sort ::= ⟨identifier⟩ | ( ⟨identifier⟩ ⟨sort⟩+ )
+    sort ::= identifier(id) { extra.0.visit_simple_sort(id)? }
+    sort ::= LeftParen identifier(id) sorts(sorts) RightParen { extra.0.visit_parameterized_sort(id, sorts)? }
+
+    sorts ::= sort(x) { vec![x] }
+    sorts ::= sorts(mut xs) sort(x) { xs.push(x); xs }
+
+    // qual_identifier ::= ⟨identifier⟩ | ( as ⟨identifier⟩ ⟨sort⟩ )
+    qual_identifier ::= identifier(x) { extra.0.visit_simple_identifier(x)? }
+    qual_identifier ::= LeftParen As identifier(id) sort(s) RightParen { extra.0.visit_sorted_identifier(id, s)? }
+
+    // constant ::= ⟨numeral⟩ | ⟨decimal⟩ | ⟨hexadecimal⟩ | ⟨binary⟩ | ⟨string⟩
+    constant ::= Numeral(x) { extra.0.visit_numeral_constant(x)? }
+    constant ::= Decimal(x) { extra.0.visit_decimal_constant(x)? }
+    constant ::= Hexadecimal(x) { extra.0.visit_hexadecimal_constant(x)? }
+    constant ::= Binary(x) { extra.0.visit_binary_constant(x)? }
+    constant ::= String(x) { extra.0.visit_string_constant(x)? }
+
+    // ⟨var_binding⟩ ::= ( ⟨symbol⟩ ⟨term⟩ )
+    var_binding ::= LeftParen fresh_symbol(s) term(t) RightParen { (s, t) }
+
+    var_bindings ::= var_binding(x) { vec![x] }
+    var_bindings ::= var_bindings(mut xs) var_binding(x) { xs.push(x); xs }
+
+    // ⟨sorted_var⟩ ::= ( ⟨symbol⟩ ⟨sort⟩ )
+    sorted_var ::= LeftParen fresh_symbol(s) sort(x) RightParen { (s, x) }
+
+    sorted_vars ::= sorted_var(x) { vec![x] }
+    sorted_vars ::= sorted_vars(mut xs) sorted_var(x) { xs.push(x); xs }
+
+    // pattern ::= ⟨symbol⟩ | ( ⟨symbol⟩ ⟨symbol⟩+ )
+    pattern ::= any_symbol(x) { vec![x] }
+    pattern ::= LeftParen pattern_symbols(xs) RightParen { xs }
+
+    // ⟨match_case⟩ ::= ( ⟨pattern⟩ ⟨term⟩ )
+    match_case ::= LeftParen pattern(p) term(t) RightParen { (p, t) }
+
+    match_cases ::= match_case(x) { vec![x] }
+    match_cases ::= match_cases(mut xs) match_case(x) { xs.push(x); xs }
+
+    // terms ::= ...
+    //   ⟨spec_constant⟩
+    term ::= constant(x) { extra.0.visit_constant(x)? }
+    //   ⟨qual_identifier⟩
+    term ::= qual_identifier(x) { extra.0.visit_qual_identifier(x)? }
+    //   ( let ( ⟨var_binding⟩+ ) ⟨term⟩ )
+    term ::= LeftParen Let LeftParen var_bindings(xs) RightParen term(t) RightParen { extra.0.visit_let(xs, t)? }
+    //   ( forall ( ⟨sorted_var⟩+ ) ⟨term⟩ )
+    term ::= LeftParen Forall LeftParen sorted_vars(xs) RightParen term(t) RightParen { extra.0.visit_forall(xs, t)? }
+    //   ( exists ( ⟨sorted_var⟩+ ) ⟨term⟩ )
+    term ::= LeftParen Exists LeftParen sorted_vars(xs) RightParen term(t) RightParen { extra.0.visit_exists(xs, t)? }
+    //   ( match ⟨term⟩ ( ⟨match_case⟩+ ) )
+    term ::= LeftParen Match term(t) LeftParen match_cases(xs) RightParen RightParen { extra.0.visit_match(t, xs)? }
+    //   ( ! ⟨term⟩ ⟨attribute⟩+ )
+    term ::= LeftParen Exclam term(t) attributes(xs) RightParen { extra.0.visit_attributes(t, xs)? }
+    //   ( ⟨qual_identifier ⟩ ⟨term⟩+ )
+    term ::= LeftParen qual_identifier(id) terms(xs) RightParen { extra.0.visit_application(id, xs)? }
+
+    terms ::= term(x) { vec![x] }
+    terms ::= terms(mut xs) term(x) { xs.push(x); xs }
+
+    // prop_literal ::= ⟨symbol⟩ | ( not ⟨symbol⟩ )
+    prop_literal ::= bound_symbol(x) { (x, true) }
+    prop_literal ::= LeftParen Symbol(s) bound_symbol(x) RightParen {
+        if s != "not" {
+            return Err(extra.0.parsing_error(extra.1.clone(), format!("invalid prop_literal: found {} instead of `not`", s)));
+        }
+        (x, false)
+    }
+
+    prop_literals ::= prop_literal(x) { vec![x] }
+    prop_literals ::= prop_literals(mut xs) prop_literal(x) { xs.push(x); xs }
+
+    // ⟨selector_dec⟩ ::= ( ⟨symbol⟩ ⟨sort⟩ )
+    selector_dec ::= LeftParen fresh_symbol(x) sort(s) RightParen { (x, s) }
+
+    selector_decs ::= selector_dec(x) { vec![x] }
+    selector_decs ::= selector_decs(mut xs) selector_dec(x) { xs.push(x); xs }
+
+    // constructor_dec ::= ( ⟨symbol⟩ ⟨selector_dec⟩∗ )
+    constructor_dec ::= LeftParen fresh_symbol(x) selector_decs?(xs) RightParen
+    {
+        visitors::ConstructorDec { symbol:x, selectors:xs.unwrap_or_else(Vec::new) }
+    }
+
+    constructor_decs ::= constructor_dec(x) { vec![x] }
+    constructor_decs ::= constructor_decs(mut xs) constructor_dec(x) { xs.push(x); xs }
+
+    // datatype_dec ::= ( ⟨constructor_dec⟩+ ) | ( par ( ⟨symbol⟩+ ) ( ⟨constructor_dec⟩+ ) )
+    datatype_dec ::= LeftParen constructor_decs(xs) RightParen
+    {
+        visitors::DatatypeDec { parameters: Vec::new(), constructors: xs }
+    }
+    datatype_dec ::= LeftParen Par LeftParen fresh_symbols(ps) RightParen LeftParen constructor_decs(xs) RightParen RightParen
+    {
+        visitors::DatatypeDec { parameters: ps, constructors: xs }
+    }
+
+    datatype_decs ::= datatype_dec(x) { vec![x] }
+    datatype_decs ::= datatype_decs(mut xs) datatype_dec(x) { xs.push(x); xs }
+
+    // function_dec ::= ⟨symbol⟩ ( ⟨sorted_var⟩∗ ) ⟨sort⟩
+    function_dec ::= fresh_symbol(x) LeftParen sorted_vars?(xs) RightParen sort(s)
+    {
+        visitors::FunctionDec {
+            name: x,
+            parameters: xs.unwrap_or_else(Vec::new),
+            result: s,
+        }
+    }
+
+    function_decs ::= function_dec(x) { vec![x] }
+    function_decs ::= function_decs(mut xs) function_dec(x) { xs.push(x); xs }
+
+    // sort_dec ::= ( ⟨symbol⟩ ⟨numeral⟩ )
+    sort_dec ::= LeftParen fresh_symbol(x) Numeral(num) RightParen { (x, num) }
+
+    sort_decs ::= sort_dec(x) { vec![x] }
+    sort_decs ::= sort_decs(mut xs) sort_dec(x) { xs.push(x); xs }
+
+    // command ::= ...
+    //   ( assert ⟨term⟩ )
+    command ::= LeftParen Assert term(t) RightParen { extra.0.visit_assert(t)? }
+    //   ( check-sat )
+    command ::= LeftParen CheckSat RightParen { extra.0.visit_check_sat()? }
+    //   ( check-sat-assuming ( ⟨prop_literal⟩∗ ) )
+    command ::= LeftParen CheckSatAssuming LeftParen prop_literals?(xs) RightParen RightParen
+    {
+        extra.0.visit_check_sat_assuming(xs.unwrap_or_else(Vec::new))?
+    }
+    //   ( declare-const ⟨symbol⟩ ⟨sort⟩ )
+    command ::= LeftParen DeclareConst fresh_symbol(x) sort(s) RightParen
+    {
+        extra.0.visit_declare_const(x, s)?
+    }
+    //   ( declare-datatype ⟨symbol⟩ ⟨datatype_dec⟩)
+    command ::= LeftParen DeclareDatatype fresh_symbol(s) datatype_dec(d) RightParen
+    {
+        extra.0.visit_declare_datatype(s, d)?
+    }
+    //   ( declare-datatypes ( ⟨sort_dec⟩n+1 ) ( ⟨datatype_dec⟩n+1 ) )
+    command ::= LeftParen DeclareDatatypes LeftParen sort_decs(sorts) RightParen LeftParen datatype_decs(datatypes) RightParen RightParen
+    {
+        if sorts.len() == datatypes.len() {
+            let results = sorts
+                .into_iter()
+                .zip(datatypes.into_iter())
+                .map(|((sort, arity), datatype)| (sort, arity, datatype))
+                .collect::<Vec<_>>();
+            extra.0.visit_declare_datatypes(results)?
+        } else {
+            return Err(extra.0.parsing_error(extra.1.clone(), format!("wrong number of types in `declare-datatypes`: {} instead of {}", datatypes.len(), sorts.len())));
+        }
+    }
+    //   ( declare-fun ⟨symbol⟩ ( ⟨sort⟩∗ ) ⟨sort⟩ )
+    command ::= LeftParen DeclareFun fresh_symbol(x) LeftParen sorts?(xs) RightParen sort(r) RightParen
+    {
+        extra.0.visit_declare_fun(x, xs.unwrap_or_else(Vec::new), r)?
+    }
+    //   ( declare-sort ⟨symbol⟩ ⟨numeral⟩ )
+    command ::= LeftParen DeclareSort fresh_symbol(x) Numeral(num) RightParen
+    {
+        extra.0.visit_declare_sort(x, num)?
+    }
+    //   ( define-fun ⟨function_dec⟩ ⟨term⟩ )
+    command ::= LeftParen DefineFun function_dec(d) term(x) RightParen
+    {
+        extra.0.visit_define_fun(d, x)?
+    }
+    //   ( define-fun-rec ⟨function_dec⟩ ⟨term⟩ )
+    command ::= LeftParen DefineFunRec function_dec(d) term(x) RightParen
+    {
+        extra.0.visit_define_fun_rec(d, x)?
+    }
+    //   ( define-funs-rec ( ( ⟨function_dec⟩ )n+1 ) ( ⟨term⟩n+1 ) )
+    command ::= LeftParen DefineFunsRec LeftParen function_decs(sigs) RightParen LeftParen terms(xs) RightParen RightParen
+    {
+        if sigs.len() == xs.len() {
+            let defs = sigs.into_iter().zip(xs.into_iter()).collect::<Vec<_>>();
+            extra.0.visit_define_funs_rec(defs)?
+        } else {
+            return Err(extra.0.parsing_error(extra.1.clone(), format!("wrong number of function bodies in `define-funs-rec`: {} instead of {}", xs.len(), sigs.len())));
+        }
+    }
+    //   ( define-sort ⟨symbol⟩ ( ⟨symbol⟩∗ ) ⟨sort⟩ )
+    command ::= LeftParen DefineSort fresh_symbol(x) LeftParen fresh_symbols?(xs) RightParen sort(r) RightParen
+    {
+        extra.0.visit_define_sort(x, xs.unwrap_or_else(Vec::new), r)?
+    }
+    //   ( echo ⟨string⟩ )
+    command ::= LeftParen Echo String(x) RightParen { extra.0.visit_echo(x)? }
+    //   ( exit )
+    command ::= LeftParen Exit RightParen { extra.0.visit_exit()? }
+    //   ( get-assertions )
+    command ::= LeftParen GetAssertions RightParen { extra.0.visit_get_assertions()? }
+    //   ( get-assignment )
+    command ::= LeftParen GetAssignment RightParen { extra.0.visit_get_assignment()? }
+    //   ( get-info ⟨info_flag⟩ )
+    command ::= LeftParen GetInfo keyword(x) RightParen { extra.0.visit_get_info(x)? }
+    //   ( get-model )
+    command ::= LeftParen GetModel RightParen { extra.0.visit_get_model()? }
+    //   ( get-option ⟨keyword⟩ )
+    command ::= LeftParen GetOption keyword(x) RightParen { extra.0.visit_get_option(x)? }
+    //   ( get-proof )
+    command ::= LeftParen GetProof RightParen { extra.0.visit_get_proof()? }
+    //   ( get-unsat-assumptions )
+    command ::= LeftParen GetUnsatAssumptions RightParen { extra.0.visit_get_unsat_assumptions()? }
+    //   ( get-unsat-core )
+    command ::= LeftParen GetUnsatCore RightParen { extra.0.visit_get_unsat_core()? }
+    //   ( get-value )
+    command ::= LeftParen GetValue terms(xs) RightParen { extra.0.visit_get_value(xs)? }
+    //   ( pop ⟨numeral⟩ )
+    command ::= LeftParen Pop Numeral(x) RightParen { extra.0.visit_pop(x)? }
+    //   ( push ⟨numeral⟩ )
+    command ::= LeftParen Push Numeral(x) RightParen { extra.0.visit_push(x)? }
+    //   ( reset )
+    command ::= LeftParen Reset RightParen { extra.0.visit_reset()? }
+    //   ( reset-assertions )
+    command ::= LeftParen ResetAssertions RightParen { extra.0.visit_reset_assertions()? }
+    //   ( set-info ⟨attribute⟩ )
+    command ::= LeftParen SetInfo keyword(k) attribute_value(v) RightParen { extra.0.visit_set_info(k, v)? }
+    //   ( set-logic ⟨symbol⟩ )
+    command ::= LeftParen SetLogic bound_symbol(x) RightParen { extra.0.visit_set_logic(x)? }
+    //   ( set-option ⟨attribute⟩ )
+    command ::= LeftParen SetOption keyword(k) attribute_value(v) RightParen { extra.0.visit_set_option(k, v)? }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::smt2parser::{concrete::*, lexer::Lexer};
+
+    pub(crate) fn parse_tokens<I: IntoIterator<Item = Token>>(tokens: I) -> Result<Command, Error> {
+        let mut builder = SyntaxBuilder::default();
+        let mut position = crate::smt2parser::Position::default();
+        let mut p = Parser::new((&mut builder, &mut position));
+        for token in tokens.into_iter() {
+            p.parse(token)?;
+        }
+        Ok(p.end_of_input()?.0)
+    }
+
+    #[test]
+    fn test_echo() {
+        let value = parse_tokens(vec![
+            Token::LeftParen,
+            Token::Echo,
+            Token::String("foo".into()),
+            Token::RightParen,
+        ])
+        .unwrap();
+        assert_eq!(
+            value,
+            Command::Echo {
+                message: "foo".into()
+            }
+        );
+    }
+
+    #[test]
+    fn test_assert_term() {
+        let value = parse_tokens(Lexer::new(&b"(assert 12)"[..])).unwrap();
+        assert_eq!(
+            value,
+            Command::Assert {
+                term: Term::Constant(Constant::Numeral(num::BigUint::from(12u32))),
+            }
+        );
+
+        let value = parse_tokens(Lexer::new(&b"(assert (as A B))"[..])).unwrap();
+        assert_eq!(
+            value,
+            Command::Assert {
+                term: Term::QualIdentifier(QualIdentifier::Sorted {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("A".into())
+                    },
+                    sort: Sort::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("B".into())
+                        }
+                    },
+                })
+            },
+        );
+
+        let value = parse_tokens(Lexer::new(&b"(assert (let ((x (f x 2))) (= x 3)))"[..])).unwrap();
+        assert_eq!(
+            value,
+            Command::Assert {
+                term: Term::Let {
+                    var_bindings: vec![(
+                        Symbol("x".into()),
+                        Term::Application {
+                            qual_identifier: QualIdentifier::Simple {
+                                identifier: Identifier::Simple {
+                                    symbol: Symbol("f".into())
+                                }
+                            },
+                            arguments: vec![
+                                Term::QualIdentifier(QualIdentifier::Simple {
+                                    identifier: Identifier::Simple {
+                                        symbol: Symbol("x".into())
+                                    }
+                                }),
+                                Term::Constant(Constant::Numeral(num::BigUint::from(2u32)))
+                            ]
+                        }
+                    )],
+                    term: Box::new(Term::Application {
+                        qual_identifier: QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("=".into())
+                            }
+                        },
+                        arguments: vec![
+                            Term::QualIdentifier(QualIdentifier::Simple {
+                                identifier: Identifier::Simple {
+                                    symbol: Symbol("x".into())
+                                }
+                            }),
+                            Term::Constant(Constant::Numeral(num::BigUint::from(3u32)))
+                        ]
+                    }),
+                }
+            }
+        );
+
+        let value = parse_tokens(Lexer::new(
+            &b"(assert (forall ((x Bool) (y Int)) (f x y))\n ; dfg \n )"[..],
+        ))
+        .unwrap();
+        assert!(matches!(
+            value,
+            Command::Assert {
+                term: Term::Forall { .. }
+            }
+        ));
+
+        let result = parse_tokens(Lexer::new(&b"(assert (forall () (f x y)))"[..]));
+        assert!(result.is_err());
+
+        let value = parse_tokens(Lexer::new(
+            &b"(assert ( ;foo\n match 3 ( (x (+ x 2)) ) ))"[..],
+        ))
+        .unwrap();
+        assert!(matches!(
+            value,
+            Command::Assert {
+                term: Term::Match { .. }
+            }
+        ));
+
+        let value = parse_tokens(Lexer::new(&b"(assert ( ! 3 :f 1 :g (a 3) ))"[..])).unwrap();
+        assert!(matches!(
+            value,
+            Command::Assert {
+                term: Term::Attributes { .. }
+            }
+        ));
+
+        let value = parse_tokens(Lexer::new(&b"(assert ( f 1 2 3 ))"[..])).unwrap();
+        assert!(matches!(
+            value,
+            Command::Assert {
+                term: Term::Application { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn test_declare_datatypes_with_comment() {
+        let value = parse_tokens(Lexer::new(&b"(declare-datatypes ((T@$TypeValue 0)(T@$TypeValueArray 0)) ((($BooleanType ) ($IntegerType ) ($AddressType ) ($StrType ) ($VectorType (|t#$VectorType| T@$TypeValue) ) ($StructType (|name#$StructType| T@$TypeName) (|ts#$StructType| T@$TypeValueArray) ) ($TypeType ) ($ErrorType ) ) (($TypeValueArray (|v#$TypeValueArray| |T@[Int]$TypeValue|) (|l#$TypeValueArray| Int) ) ) ))"[..])).unwrap();
+
+        assert!(matches!(value, Command::DeclareDatatypes { .. }));
+        // Test syntax visiting while we're at it.
+        let mut builder = crate::smt2parser::concrete::SyntaxBuilder::default();
+        assert_eq!(value, value.clone().accept(&mut builder).unwrap());
+    }
+}

--- a/aws-smt-ir/src/smt2parser/parser.rs
+++ b/aws-smt-ir/src/smt2parser/parser.rs
@@ -593,5 +593,4 @@ pub(crate) mod tests {
         ));
     }
     // end of updates
-
 }

--- a/aws-smt-ir/src/smt2parser/renaming.rs
+++ b/aws-smt-ir/src/smt2parser/renaming.rs
@@ -53,6 +53,9 @@ where
     }
 }
 
+// Amazon modification: removed config from SymbolNormalizer
+// to fix a compiler warning.
+
 /// A [`Rewriter`] implementation that normalizes local symbols into `x0`, `x1`, etc.
 /// * Normalization applies to all locally resolved symbols.
 /// * A different prefix is applied depending on the symbol kind (datatype, sorts,
@@ -64,8 +67,6 @@ where
 pub struct SymbolNormalizer<V> {
     /// The underlying syntax visitor.
     visitor: V,
-    /// Configuration.
-    config: SymbolNormalizerConfig,
     /// Original names of current local symbols, indexed by kind.
     current_local_symbols: BTreeMap<SymbolKind, Vec<String>>,
     /// Currently bound symbols.
@@ -166,7 +167,7 @@ impl<V> SymbolNormalizer<V> {
         }
         Self {
             visitor,
-            config,
+            // config,    Amazon change: not used
             current_local_symbols: BTreeMap::new(),
             current_bound_symbols: BTreeMap::new(),
             encoding_tables,
@@ -389,7 +390,7 @@ fn test_testers() {
             }
         }
     ));
-    let mut builder = concrete::SyntaxBuilder::default();
+    let mut builder = concrete::SyntaxBuilder;
     assert_eq!(value, value.clone().accept(&mut builder).unwrap());
     // Visit with the TesterModernizer this time.
     let mut builder = TesterModernizer::<SyntaxBuilder>::default();
@@ -432,7 +433,7 @@ fn test_declare_datatypes_renaming() {
     ))
     .unwrap();
     assert!(matches!(value2, Command::DeclareDatatypes { .. }));
-    let mut builder = SyntaxBuilder::default();
+    let mut builder = SyntaxBuilder;
     assert_eq!(value, value.clone().accept(&mut builder).unwrap());
 
     let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();

--- a/aws-smt-ir/src/smt2parser/renaming.rs
+++ b/aws-smt-ir/src/smt2parser/renaming.rs
@@ -1,0 +1,600 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//! Utilities for name resolution and renaming of bound symbols.
+
+use crate::smt2parser::{
+    concrete::*,
+    rewriter::Rewriter,
+    visitors::{Identifier, Index, Smt2Visitor, SymbolKind},
+};
+use num::ToPrimitive;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// A [`Rewriter`] implementation that converts old-style testers `is-Foo` into a proper indexed identifier `(_ is Foo)`.
+#[derive(Debug, Default)]
+pub struct TesterModernizer<V>(V);
+
+impl<V> TesterModernizer<V> {
+    pub fn new(visitor: V) -> Self {
+        Self(visitor)
+    }
+}
+
+impl<V, Error> Rewriter for TesterModernizer<V>
+where
+    V: Smt2Visitor<QualIdentifier = QualIdentifier, Symbol = Symbol, Error = Error>,
+{
+    type V = V;
+    type Error = Error;
+
+    fn visitor(&mut self) -> &mut V {
+        &mut self.0
+    }
+
+    fn visit_simple_identifier(
+        &mut self,
+        value: Identifier<Symbol>,
+    ) -> Result<QualIdentifier, Error> {
+        let value = match value {
+            Identifier::Simple { symbol } if symbol.0.starts_with("is-") => {
+                let is = self.0.visit_bound_symbol("is".to_string())?;
+                let name = self.0.visit_bound_symbol(symbol.0[3..].to_string())?;
+                Identifier::Indexed {
+                    symbol: is,
+                    indices: vec![Index::Symbol(name)],
+                }
+            }
+            v => v,
+        };
+        self.0.visit_simple_identifier(value)
+    }
+}
+
+/// A [`Rewriter`] implementation that normalizes local symbols into `x0`, `x1`, etc.
+/// * Normalization applies to all locally resolved symbols.
+/// * A different prefix is applied depending on the symbol kind (datatype, sorts,
+/// functions, variables, etc).
+/// * "Global" symbols (those which don't resolve locally) are ignored.
+/// * Symbol names may be re-used after a `reset` or a `pop` command, but are otherwise
+/// unique (disregarding the more limited lexical scoping of variables).
+#[derive(Debug, Default)]
+pub struct SymbolNormalizer<V> {
+    /// The underlying syntax visitor.
+    visitor: V,
+    /// Configuration.
+    config: SymbolNormalizerConfig,
+    /// Original names of current local symbols, indexed by kind.
+    current_local_symbols: BTreeMap<SymbolKind, Vec<String>>,
+    /// Currently bound symbols.
+    current_bound_symbols: BTreeMap<String, Vec<LocalSymbolRef>>,
+    /// Encoding tables for name randomization (if any).
+    encoding_tables: BTreeMap<SymbolKind, EncodingTable>,
+    /// Support the scoping of symbols with `push` and `pop` commands.
+    scopes: Vec<Scope>,
+    /// Accumulate symbols that were not resolved (thus ignored).
+    global_symbols: BTreeSet<String>,
+    /// Track the maximal number of local variables simultaneously used, indexed per kind.
+    max_local_symbols: BTreeMap<SymbolKind, usize>,
+}
+
+/// Reference to a local symbol.
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+struct LocalSymbolRef {
+    kind: SymbolKind,
+    index: usize,
+}
+
+/// Configuration for SymbolNormalizer.
+#[derive(Debug, Default)]
+pub struct SymbolNormalizerConfig {
+    /// For each kind K and value N in the map, the first N local variables of kind K will
+    /// be assigned a randomized index in the range 0..N. Other variables will be given a
+    /// sequential index (greater or equal to N).
+    pub randomization_space: BTreeMap<SymbolKind, usize>,
+    /// Seed for the randomization of local symbols.
+    pub randomization_seed: u64,
+}
+
+struct EncodingTable {
+    max_size: usize,
+    permutor: permutation_iterator::Permutor,
+    numbers: Vec<usize>,
+    indices: BTreeMap<usize, usize>,
+}
+
+impl std::fmt::Debug for EncodingTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("EncodingTable")
+            .field("max_size", &self.max_size)
+            .field("numbers", &self.numbers)
+            .field("indices", &self.indices)
+            .finish()
+    }
+}
+
+impl EncodingTable {
+    fn new(seed: u64, max_size: usize) -> Self {
+        let permutor = permutation_iterator::Permutor::new_with_u64_key(max_size as u64, seed);
+        Self {
+            max_size,
+            permutor,
+            numbers: Vec::new(),
+            indices: BTreeMap::new(),
+        }
+    }
+
+    fn encode(&mut self, x: usize) -> usize {
+        if x >= self.max_size {
+            return x;
+        }
+        for _ in self.numbers.len()..=x {
+            let y = self
+                .permutor
+                .next()
+                .expect("should not be called more than max_size times")
+                as usize;
+            self.indices.insert(y, self.numbers.len());
+            self.numbers.push(y);
+        }
+        self.numbers[x]
+    }
+
+    fn decode(&self, x: usize) -> usize {
+        *self.indices.get(&x).unwrap_or(&x)
+    }
+}
+
+/// Track the size of `current_local_symbols` and `current_bound_symbols` so that we can
+/// backtrack later.
+#[derive(Debug, Default)]
+struct Scope {
+    /// Number of local symbols index by kind.
+    local: BTreeMap<SymbolKind, usize>,
+    /// Current number of bound symbols.
+    bound: BTreeMap<String, usize>,
+}
+
+impl<V> SymbolNormalizer<V> {
+    pub fn new(visitor: V, config: SymbolNormalizerConfig) -> Self {
+        let mut encoding_tables = BTreeMap::new();
+        for (kind, n) in config.randomization_space.iter() {
+            let table = EncodingTable::new(config.randomization_seed + *kind as u64, *n);
+            encoding_tables.insert(*kind, table);
+        }
+        Self {
+            visitor,
+            config,
+            current_local_symbols: BTreeMap::new(),
+            current_bound_symbols: BTreeMap::new(),
+            encoding_tables,
+            global_symbols: BTreeSet::new(),
+            scopes: Vec::new(),
+            max_local_symbols: BTreeMap::new(),
+        }
+    }
+
+    fn get_external_symbol(table: Option<&mut EncodingTable>, r: LocalSymbolRef) -> Symbol {
+        use SymbolKind::*;
+        let prefix = match r.kind {
+            Unknown => "?",
+            Variable => "x",
+            Constant => "k",
+            Function => "f",
+            Sort => "S",
+            Datatype => "T",
+            TypeVar => "X",
+            Constructor => "c",
+            Selector => "s",
+        };
+        let index = match table {
+            Some(table) => table.encode(r.index),
+            None => r.index,
+        };
+        Symbol(format!("{}{}", prefix, index))
+    }
+
+    fn parse_external_symbol(&self, s: &Symbol) -> LocalSymbolRef {
+        use SymbolKind::*;
+        let kind = match &s.0[0..1] {
+            "?" => Unknown,
+            "x" => Variable,
+            "k" => Constant,
+            "f" => Function,
+            "S" => Sort,
+            "T" => Datatype,
+            "X" => TypeVar,
+            "c" => Constructor,
+            "s" => Selector,
+            _ => panic!("cannot parse symbol kind"),
+        };
+        let index = str::parse(&s.0[1..]).expect("cannot parse symbol index");
+        let index = match self.encoding_tables.get(&kind) {
+            Some(table) => table.decode(index),
+            None => index,
+        };
+        LocalSymbolRef { kind, index }
+    }
+
+    /// Original names of the current local symbols.
+    pub fn current_local_symbols(&self) -> &BTreeMap<SymbolKind, Vec<String>> {
+        &self.current_local_symbols
+    }
+
+    /// Max number of the local symbols simulatenously used.
+    pub fn max_local_symbols(&self) -> &BTreeMap<SymbolKind, usize> {
+        &self.max_local_symbols
+    }
+
+    fn original_symbol_name(&self, r: LocalSymbolRef) -> String {
+        self.current_local_symbols.get(&r.kind).unwrap()[r.index].to_string()
+    }
+
+    /// All symbol names that failed to be resolved locally at least once (e.g. theory defined symbols).
+    pub fn global_symbols(&self) -> &BTreeSet<String> {
+        &self.global_symbols
+    }
+
+    fn push_scope(&mut self) {
+        self.scopes.push(Scope {
+            local: self
+                .current_local_symbols
+                .iter()
+                .map(|(k, v)| (*k, v.len()))
+                .collect(),
+            bound: self
+                .current_bound_symbols
+                .iter()
+                .map(|(k, v)| (k.clone(), v.len()))
+                .collect(),
+        });
+    }
+
+    fn truncate_vectors<T: Ord, S>(sizes: &BTreeMap<T, usize>, vectors: &mut BTreeMap<T, Vec<S>>) {
+        let vs = std::mem::take(vectors);
+        let vs = vs
+            .into_iter()
+            .filter_map(|(k, mut v)| match sizes.get(&k) {
+                Some(n) => {
+                    v.truncate(*n);
+                    Some((k, v))
+                }
+                None => None,
+            })
+            .collect();
+        *vectors = vs;
+    }
+
+    fn pop_scope(&mut self) {
+        if let Some(scope) = self.scopes.pop() {
+            Self::truncate_vectors(&scope.local, &mut self.current_local_symbols);
+            Self::truncate_vectors(&scope.bound, &mut self.current_bound_symbols);
+        }
+    }
+}
+
+impl<V, Error> Rewriter for SymbolNormalizer<V>
+where
+    V: Smt2Visitor<Symbol = Symbol, Command = Command, Error = Error>,
+{
+    type V = V;
+    type Error = Error;
+
+    fn visitor(&mut self) -> &mut V {
+        &mut self.visitor
+    }
+
+    fn visit_push(&mut self, level: crate::smt2parser::Numeral) -> Result<Command, Error> {
+        for _ in 0..level.to_usize().expect("too many levels") {
+            self.push_scope();
+        }
+        let value = self.visitor().visit_push(level)?;
+        self.process_command(value)
+    }
+
+    fn visit_pop(&mut self, level: crate::smt2parser::Numeral) -> Result<Command, Error> {
+        for _ in 0..level.to_usize().expect("too many levels") {
+            self.pop_scope();
+        }
+        let value = self.visitor().visit_pop(level)?;
+        self.process_command(value)
+    }
+
+    fn visit_reset(&mut self) -> Result<Command, Error> {
+        self.current_local_symbols.clear();
+        self.current_bound_symbols.clear();
+        self.scopes.clear();
+        let value = self.visitor().visit_reset()?;
+        self.process_command(value)
+    }
+
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Symbol, Error> {
+        let tables = &mut self.encoding_tables;
+        let value = self
+            .current_bound_symbols
+            .get(&value)
+            .map(|v| {
+                let r = *v.last().unwrap();
+                Self::get_external_symbol(tables.get_mut(&r.kind), r)
+            })
+            .unwrap_or_else(|| {
+                self.global_symbols.insert(value.clone());
+                Symbol(value)
+            });
+        self.process_symbol(value)
+    }
+
+    fn visit_fresh_symbol(&mut self, value: String, kind: SymbolKind) -> Result<Symbol, Error> {
+        let r = LocalSymbolRef {
+            kind,
+            index: match self.current_local_symbols.get(&kind) {
+                Some(v) => v.len(),
+                None => 0,
+            },
+        };
+        self.current_local_symbols
+            .entry(kind)
+            .or_default()
+            .push(value);
+        let n = self.max_local_symbols.entry(kind).or_default();
+        *n = std::cmp::max(*n, r.index + 1);
+        let s = Self::get_external_symbol(self.encoding_tables.get_mut(&r.kind), r);
+        self.process_symbol(s)
+    }
+
+    fn bind_symbol(&mut self, symbol: &Symbol) {
+        let r = self.parse_external_symbol(symbol);
+        let name = self.original_symbol_name(r);
+        self.current_bound_symbols.entry(name).or_default().push(r);
+    }
+
+    fn unbind_symbol(&mut self, symbol: &Symbol) {
+        use std::collections::btree_map;
+        let r = self.parse_external_symbol(symbol);
+        let name = self.original_symbol_name(r);
+        match self.current_bound_symbols.entry(name.clone()) {
+            btree_map::Entry::Occupied(mut e) => {
+                if let Some(scope) = self.scopes.last() {
+                    if let Some(n) = scope.bound.get(&name) {
+                        // Never unbind names from the previous scope.
+                        assert!(e.get().len() > *n);
+                    }
+                }
+                // Check that we unbind the expected symbol.
+                assert_eq!(e.get_mut().pop().unwrap(), r);
+                if e.get().is_empty() {
+                    e.remove_entry();
+                }
+            }
+            _ => panic!("invalid entry"),
+        }
+    }
+}
+
+#[test]
+fn test_testers() {
+    use crate::smt2parser::{concrete, lexer::Lexer, parser::tests::parse_tokens};
+
+    let value = parse_tokens(Lexer::new(&b"(assert (is-Foo 3))"[..])).unwrap();
+    assert!(matches!(
+        value,
+        Command::Assert {
+            term: Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple { .. }
+                },
+                ..
+            }
+        }
+    ));
+    let mut builder = concrete::SyntaxBuilder::default();
+    assert_eq!(value, value.clone().accept(&mut builder).unwrap());
+    // Visit with the TesterModernizer this time.
+    let mut builder = TesterModernizer::<SyntaxBuilder>::default();
+    assert!(matches!(
+        value.accept(&mut builder).unwrap(),
+        Command::Assert {
+            term: Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Indexed { .. }
+                },
+                ..
+            }
+        }
+    ));
+}
+
+#[test]
+fn test_declare_datatypes_renaming() {
+    use crate::smt2parser::{lexer::Lexer, parser::tests::parse_tokens};
+
+    let value = parse_tokens(Lexer::new(&b"
+(declare-datatypes (
+    (Type 0)
+    (TypeArray 0)
+)(
+    ((IntType) (VectorType (typeOfVectorType Type)) (StructType (nameOfStructType Name) (typesOfStructType TypeArray)))
+    ((TypeArray (valueOfTypeArray (Array Int Type)) (lengthOfTypeArray Int)))
+))"[..])).unwrap();
+    assert!(matches!(value, Command::DeclareDatatypes { .. }));
+
+    let value2 = parse_tokens(Lexer::new(
+        &b"
+(declare-datatypes (
+    (T0 0)
+    (T1 0)
+)(
+    ((c0) (c1 (s0 T0)) (c2 (s1 Name) (s2 T1)))
+    ((c3 (s3 (Array Int T0)) (s4 Int)))
+))"[..],
+    ))
+    .unwrap();
+    assert!(matches!(value2, Command::DeclareDatatypes { .. }));
+    let mut builder = SyntaxBuilder::default();
+    assert_eq!(value, value.clone().accept(&mut builder).unwrap());
+
+    let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();
+    assert_eq!(value2, value.accept(&mut builder).unwrap());
+
+    assert_eq!(
+        *builder
+            .max_local_symbols()
+            .get(&SymbolKind::Constructor)
+            .unwrap(),
+        4
+    );
+    assert_eq!(
+        *builder
+            .max_local_symbols()
+            .get(&SymbolKind::Selector)
+            .unwrap(),
+        5
+    );
+}
+
+#[test]
+fn test_symbol_renaming() {
+    use crate::smt2parser::concrete::*;
+
+    // (assert (let ((x (f x 2))) (= x 3)))
+    let command = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+
+    let mut builder = SymbolNormalizer::<SyntaxBuilder>::default();
+
+    let command2 = command.accept(&mut builder).unwrap();
+    let command3 = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x0".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x0".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+
+    assert_eq!(command2, command3);
+    assert_eq!(
+        builder.current_local_symbols().iter().collect::<Vec<_>>(),
+        vec![(&SymbolKind::Variable, &vec!["x".to_string()])]
+    );
+    assert_eq!(
+        builder.global_symbols().iter().collect::<Vec<_>>(),
+        vec!["=", "f", "x"]
+    );
+}
+
+#[test]
+fn test_random_renaming() {
+    use crate::smt2parser::{lexer::Lexer, parser::tests::parse_tokens};
+
+    let value = parse_tokens(Lexer::new(&b"
+(declare-datatypes (
+    (Type 0)
+    (TypeArray 0)
+)(
+    ((IntType) (VectorType (typeOfVectorType Type)) (StructType (nameOfStructType Name) (typesOfStructType TypeArray)))
+    ((TypeArray (valueOfTypeArray (Array Int Type)) (lengthOfTypeArray Int)))
+))"[..])).unwrap();
+    assert!(matches!(value, Command::DeclareDatatypes { .. }));
+
+    let value2 = parse_tokens(Lexer::new(
+        &b"
+(declare-datatypes (
+    (T5 0)
+    (T7 0)
+)(
+    ((c0) (c1 (s3 T5)) (c2 (s1 Name) (s0 T7)))
+    ((c3 (s2 (Array Int T5)) (s4 Int)))
+))"[..],
+    ))
+    .unwrap();
+
+    let mut config = SymbolNormalizerConfig::default();
+    config.randomization_space.insert(SymbolKind::Selector, 4);
+    config.randomization_space.insert(SymbolKind::Datatype, 12);
+    config.randomization_seed = 2;
+
+    let mut builder = SymbolNormalizer::new(SyntaxBuilder, config);
+    assert_eq!(value2, value.accept(&mut builder).unwrap());
+
+    assert_eq!(
+        *builder
+            .max_local_symbols()
+            .get(&SymbolKind::Constructor)
+            .unwrap(),
+        4
+    );
+    assert_eq!(
+        *builder
+            .max_local_symbols()
+            .get(&SymbolKind::Selector)
+            .unwrap(),
+        5
+    );
+}

--- a/aws-smt-ir/src/smt2parser/rewriter.rs
+++ b/aws-smt-ir/src/smt2parser/rewriter.rs
@@ -1,0 +1,1046 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#![allow(clippy::type_complexity)]
+
+//! Rewriting of Smt2 values
+
+use crate::smt2parser::{
+    visitors::{
+        AttributeValue, CommandVisitor, ConstantVisitor, DatatypeDec, FunctionDec, Identifier,
+        KeywordVisitor, QualIdentifierVisitor, SExprVisitor, Smt2Visitor, SortVisitor, SymbolKind,
+        SymbolVisitor, TermVisitor,
+    },
+    Binary, Decimal, Hexadecimal, Numeral, Position,
+};
+
+/// Helper trait to create variants of an existing Smt2Visitor.
+pub trait Rewriter {
+    type V: Smt2Visitor;
+    type Error: std::convert::From<<Self::V as Smt2Visitor>::Error>;
+
+    /// Delegate visitor
+    fn visitor(&mut self) -> &mut Self::V;
+
+    // Post-processing
+    fn process_constant(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Constant,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        Ok(value)
+    }
+    fn process_symbol(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Symbol,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        Ok(value)
+    }
+    fn process_keyword(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Keyword,
+    ) -> Result<<Self::V as Smt2Visitor>::Keyword, Self::Error> {
+        Ok(value)
+    }
+    fn process_s_expr(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::SExpr,
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        Ok(value)
+    }
+    fn process_sort(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Sort,
+    ) -> Result<<Self::V as Smt2Visitor>::Sort, Self::Error> {
+        Ok(value)
+    }
+    fn process_qual_identifier(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::QualIdentifier,
+    ) -> Result<<Self::V as Smt2Visitor>::QualIdentifier, Self::Error> {
+        Ok(value)
+    }
+    fn process_term(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        Ok(value)
+    }
+    fn process_command(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Command,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        Ok(value)
+    }
+
+    // ConstantVisitor
+    fn visit_numeral_constant(
+        &mut self,
+        value: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_numeral_constant(value)?;
+        self.process_constant(value)
+    }
+    fn visit_decimal_constant(
+        &mut self,
+        value: Decimal,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_decimal_constant(value)?;
+        self.process_constant(value)
+    }
+    fn visit_hexadecimal_constant(
+        &mut self,
+        value: Hexadecimal,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_hexadecimal_constant(value)?;
+        self.process_constant(value)
+    }
+    fn visit_binary_constant(
+        &mut self,
+        value: Binary,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_binary_constant(value)?;
+        self.process_constant(value)
+    }
+    fn visit_string_constant(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Constant, Self::Error> {
+        let value = self.visitor().visit_string_constant(value)?;
+        self.process_constant(value)
+    }
+
+    // SymbolVisitor
+    fn visit_bound_symbol(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        let value = self.visitor().visit_bound_symbol(value)?;
+        self.process_symbol(value)
+    }
+
+    fn visit_fresh_symbol(
+        &mut self,
+        value: String,
+        kind: SymbolKind,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        let value = self.visitor().visit_fresh_symbol(value, kind)?;
+        self.process_symbol(value)
+    }
+
+    fn visit_any_symbol(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Symbol, Self::Error> {
+        let value = self.visitor().visit_any_symbol(value)?;
+        self.process_symbol(value)
+    }
+
+    fn bind_symbol(&mut self, symbol: &<Self::V as Smt2Visitor>::Symbol) {
+        self.visitor().bind_symbol(symbol);
+    }
+
+    fn unbind_symbol(&mut self, symbol: &<Self::V as Smt2Visitor>::Symbol) {
+        self.visitor().unbind_symbol(symbol);
+    }
+
+    // KeywordVisitor
+    fn visit_keyword(
+        &mut self,
+        value: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Keyword, Self::Error> {
+        let value = self.visitor().visit_keyword(value)?;
+        self.process_keyword(value)
+    }
+
+    // SExprVisitor
+    fn visit_constant_s_expr(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Constant,
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_constant_s_expr(value)?;
+        self.process_s_expr(value)
+    }
+    fn visit_symbol_s_expr(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Symbol,
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_symbol_s_expr(value)?;
+        self.process_s_expr(value)
+    }
+    fn visit_keyword_s_expr(
+        &mut self,
+        value: <Self::V as Smt2Visitor>::Keyword,
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_keyword_s_expr(value)?;
+        self.process_s_expr(value)
+    }
+    fn visit_application_s_expr(
+        &mut self,
+        values: Vec<<Self::V as Smt2Visitor>::SExpr>,
+    ) -> Result<<Self::V as Smt2Visitor>::SExpr, Self::Error> {
+        let value = self.visitor().visit_application_s_expr(values)?;
+        self.process_s_expr(value)
+    }
+
+    // SortVisitor
+    fn visit_simple_sort(
+        &mut self,
+        identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
+    ) -> Result<<Self::V as Smt2Visitor>::Sort, Self::Error> {
+        let value = self.visitor().visit_simple_sort(identifier)?;
+        self.process_sort(value)
+    }
+    fn visit_parameterized_sort(
+        &mut self,
+        identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
+        parameters: Vec<<Self::V as Smt2Visitor>::Sort>,
+    ) -> Result<<Self::V as Smt2Visitor>::Sort, Self::Error> {
+        let value = self
+            .visitor()
+            .visit_parameterized_sort(identifier, parameters)?;
+        self.process_sort(value)
+    }
+
+    // QualIdentifierVisitor
+    fn visit_simple_identifier(
+        &mut self,
+        identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
+    ) -> Result<<Self::V as Smt2Visitor>::QualIdentifier, Self::Error> {
+        let value = self.visitor().visit_simple_identifier(identifier)?;
+        self.process_qual_identifier(value)
+    }
+    fn visit_sorted_identifier(
+        &mut self,
+        identifier: Identifier<<Self::V as Smt2Visitor>::Symbol>,
+        sort: <Self::V as Smt2Visitor>::Sort,
+    ) -> Result<<Self::V as Smt2Visitor>::QualIdentifier, Self::Error> {
+        let value = self.visitor().visit_sorted_identifier(identifier, sort)?;
+        self.process_qual_identifier(value)
+    }
+
+    // TermVisitor
+    fn visit_constant(
+        &mut self,
+        constant: <Self::V as Smt2Visitor>::Constant,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_constant(constant)?;
+        self.process_term(value)
+    }
+    fn visit_qual_identifier(
+        &mut self,
+        qual_identifier: <Self::V as Smt2Visitor>::QualIdentifier,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_qual_identifier(qual_identifier)?;
+        self.process_term(value)
+    }
+    fn visit_application(
+        &mut self,
+        qual_identifier: <Self::V as Smt2Visitor>::QualIdentifier,
+        arguments: Vec<<Self::V as Smt2Visitor>::Term>,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self
+            .visitor()
+            .visit_application(qual_identifier, arguments)?;
+        self.process_term(value)
+    }
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(
+            <Self::V as Smt2Visitor>::Symbol,
+            <Self::V as Smt2Visitor>::Term,
+        )>,
+        term: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_let(var_bindings, term)?;
+        self.process_term(value)
+    }
+    fn visit_forall(
+        &mut self,
+        vars: Vec<(
+            <Self::V as Smt2Visitor>::Symbol,
+            <Self::V as Smt2Visitor>::Sort,
+        )>,
+        term: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_forall(vars, term)?;
+        self.process_term(value)
+    }
+    fn visit_exists(
+        &mut self,
+        vars: Vec<(
+            <Self::V as Smt2Visitor>::Symbol,
+            <Self::V as Smt2Visitor>::Sort,
+        )>,
+        term: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_exists(vars, term)?;
+        self.process_term(value)
+    }
+    fn visit_match(
+        &mut self,
+        term: <Self::V as Smt2Visitor>::Term,
+        cases: Vec<(
+            Vec<<Self::V as Smt2Visitor>::Symbol>,
+            <Self::V as Smt2Visitor>::Term,
+        )>,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_match(term, cases)?;
+        self.process_term(value)
+    }
+    fn visit_attributes(
+        &mut self,
+        term: <Self::V as Smt2Visitor>::Term,
+        attributes: Vec<(
+            <Self::V as Smt2Visitor>::Keyword,
+            AttributeValue<
+                <Self::V as Smt2Visitor>::Constant,
+                <Self::V as Smt2Visitor>::Symbol,
+                <Self::V as Smt2Visitor>::SExpr,
+            >,
+        )>,
+    ) -> Result<<Self::V as Smt2Visitor>::Term, Self::Error> {
+        let value = self.visitor().visit_attributes(term, attributes)?;
+        self.process_term(value)
+    }
+
+    // CommandVisitor
+    fn visit_assert(
+        &mut self,
+        term: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_assert(term)?;
+        self.process_command(value)
+    }
+    fn visit_check_sat(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_check_sat()?;
+        self.process_command(value)
+    }
+    fn visit_check_sat_assuming(
+        &mut self,
+        literals: Vec<(<Self::V as Smt2Visitor>::Symbol, bool)>,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_check_sat_assuming(literals)?;
+        self.process_command(value)
+    }
+    fn visit_declare_const(
+        &mut self,
+        symbol: <Self::V as Smt2Visitor>::Symbol,
+        sort: <Self::V as Smt2Visitor>::Sort,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_const(symbol, sort)?;
+        self.process_command(value)
+    }
+    fn visit_declare_datatype(
+        &mut self,
+        symbol: <Self::V as Smt2Visitor>::Symbol,
+        datatype: DatatypeDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_datatype(symbol, datatype)?;
+        self.process_command(value)
+    }
+    fn visit_declare_datatypes(
+        &mut self,
+        datatypes: Vec<(
+            <Self::V as Smt2Visitor>::Symbol,
+            Numeral,
+            DatatypeDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
+        )>,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_datatypes(datatypes)?;
+        self.process_command(value)
+    }
+    fn visit_declare_fun(
+        &mut self,
+        symbol: <Self::V as Smt2Visitor>::Symbol,
+        parameters: Vec<<Self::V as Smt2Visitor>::Sort>,
+        sort: <Self::V as Smt2Visitor>::Sort,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_fun(symbol, parameters, sort)?;
+        self.process_command(value)
+    }
+    fn visit_declare_sort(
+        &mut self,
+        symbol: <Self::V as Smt2Visitor>::Symbol,
+        arity: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_declare_sort(symbol, arity)?;
+        self.process_command(value)
+    }
+    fn visit_define_fun(
+        &mut self,
+        sig: FunctionDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
+        term: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_fun(sig, term)?;
+        self.process_command(value)
+    }
+    fn visit_define_fun_rec(
+        &mut self,
+        sig: FunctionDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
+        term: <Self::V as Smt2Visitor>::Term,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_fun_rec(sig, term)?;
+        self.process_command(value)
+    }
+    fn visit_define_funs_rec(
+        &mut self,
+        funs: Vec<(
+            FunctionDec<<Self::V as Smt2Visitor>::Symbol, <Self::V as Smt2Visitor>::Sort>,
+            <Self::V as Smt2Visitor>::Term,
+        )>,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_funs_rec(funs)?;
+        self.process_command(value)
+    }
+    fn visit_define_sort(
+        &mut self,
+        symbol: <Self::V as Smt2Visitor>::Symbol,
+        parameters: Vec<<Self::V as Smt2Visitor>::Symbol>,
+        sort: <Self::V as Smt2Visitor>::Sort,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_define_sort(symbol, parameters, sort)?;
+        self.process_command(value)
+    }
+    fn visit_echo(
+        &mut self,
+        message: String,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_echo(message)?;
+        self.process_command(value)
+    }
+    fn visit_exit(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_exit()?;
+        self.process_command(value)
+    }
+    fn visit_get_assertions(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_assertions()?;
+        self.process_command(value)
+    }
+    fn visit_get_assignment(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_assignment()?;
+        self.process_command(value)
+    }
+    fn visit_get_info(
+        &mut self,
+        flag: <Self::V as Smt2Visitor>::Keyword,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_info(flag)?;
+        self.process_command(value)
+    }
+    fn visit_get_model(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_model()?;
+        self.process_command(value)
+    }
+    fn visit_get_option(
+        &mut self,
+        keyword: <Self::V as Smt2Visitor>::Keyword,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_option(keyword)?;
+        self.process_command(value)
+    }
+    fn visit_get_proof(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_proof()?;
+        self.process_command(value)
+    }
+    fn visit_get_unsat_assumptions(
+        &mut self,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_unsat_assumptions()?;
+        self.process_command(value)
+    }
+    fn visit_get_unsat_core(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_unsat_core()?;
+        self.process_command(value)
+    }
+    fn visit_get_value(
+        &mut self,
+        terms: Vec<<Self::V as Smt2Visitor>::Term>,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_get_value(terms)?;
+        self.process_command(value)
+    }
+    fn visit_pop(
+        &mut self,
+        level: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_pop(level)?;
+        self.process_command(value)
+    }
+    fn visit_push(
+        &mut self,
+        level: Numeral,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_push(level)?;
+        self.process_command(value)
+    }
+    fn visit_reset(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_reset()?;
+        self.process_command(value)
+    }
+    fn visit_reset_assertions(&mut self) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_reset_assertions()?;
+        self.process_command(value)
+    }
+    fn visit_set_info(
+        &mut self,
+        keyword: <Self::V as Smt2Visitor>::Keyword,
+        value: AttributeValue<
+            <Self::V as Smt2Visitor>::Constant,
+            <Self::V as Smt2Visitor>::Symbol,
+            <Self::V as Smt2Visitor>::SExpr,
+        >,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_set_info(keyword, value)?;
+        self.process_command(value)
+    }
+    fn visit_set_logic(
+        &mut self,
+        symbol: <Self::V as Smt2Visitor>::Symbol,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_set_logic(symbol)?;
+        self.process_command(value)
+    }
+    fn visit_set_option(
+        &mut self,
+        keyword: <Self::V as Smt2Visitor>::Keyword,
+        value: AttributeValue<
+            <Self::V as Smt2Visitor>::Constant,
+            <Self::V as Smt2Visitor>::Symbol,
+            <Self::V as Smt2Visitor>::SExpr,
+        >,
+    ) -> Result<<Self::V as Smt2Visitor>::Command, Self::Error> {
+        let value = self.visitor().visit_set_option(keyword, value)?;
+        self.process_command(value)
+    }
+}
+
+impl<R, V> ConstantVisitor for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Constant;
+    type E = R::Error;
+
+    fn visit_numeral_constant(&mut self, value: Numeral) -> Result<Self::T, Self::E> {
+        self.visit_numeral_constant(value)
+    }
+    fn visit_decimal_constant(&mut self, value: Decimal) -> Result<Self::T, Self::E> {
+        self.visit_decimal_constant(value)
+    }
+    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Result<Self::T, Self::E> {
+        self.visit_hexadecimal_constant(value)
+    }
+    fn visit_binary_constant(&mut self, value: Binary) -> Result<Self::T, Self::E> {
+        self.visit_binary_constant(value)
+    }
+    fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_string_constant(value)
+    }
+}
+
+impl<R, V> SymbolVisitor for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Symbol;
+    type E = R::Error;
+
+    fn visit_fresh_symbol(&mut self, value: String, kind: SymbolKind) -> Result<Self::T, Self::E> {
+        self.visit_fresh_symbol(value, kind)
+    }
+
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_bound_symbol(value)
+    }
+
+    fn visit_any_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_any_symbol(value)
+    }
+
+    fn bind_symbol(&mut self, symbol: &Self::T) {
+        self.bind_symbol(symbol)
+    }
+
+    fn unbind_symbol(&mut self, symbol: &Self::T) {
+        self.unbind_symbol(symbol)
+    }
+}
+
+impl<R, V> KeywordVisitor for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Keyword;
+    type E = R::Error;
+
+    fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_keyword(value)
+    }
+}
+
+impl<R, V> SExprVisitor<V::Constant, V::Symbol, V::Keyword> for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::SExpr;
+    type E = R::Error;
+
+    fn visit_constant_s_expr(&mut self, value: V::Constant) -> Result<Self::T, Self::E> {
+        self.visit_constant_s_expr(value)
+    }
+
+    fn visit_symbol_s_expr(&mut self, value: V::Symbol) -> Result<Self::T, Self::E> {
+        self.visit_symbol_s_expr(value)
+    }
+
+    fn visit_keyword_s_expr(&mut self, value: V::Keyword) -> Result<Self::T, Self::E> {
+        self.visit_keyword_s_expr(value)
+    }
+
+    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Result<Self::T, Self::E> {
+        self.visit_application_s_expr(values)
+    }
+}
+
+impl<R, V> SortVisitor<V::Symbol> for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Sort;
+    type E = R::Error;
+
+    fn visit_simple_sort(&mut self, identifier: Identifier<V::Symbol>) -> Result<Self::T, Self::E> {
+        self.visit_simple_sort(identifier)
+    }
+
+    fn visit_parameterized_sort(
+        &mut self,
+        identifier: Identifier<V::Symbol>,
+        parameters: Vec<Self::T>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_parameterized_sort(identifier, parameters)
+    }
+}
+
+impl<R, V> QualIdentifierVisitor<Identifier<V::Symbol>, V::Sort> for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::QualIdentifier;
+    type E = R::Error;
+
+    fn visit_simple_identifier(
+        &mut self,
+        identifier: Identifier<V::Symbol>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_simple_identifier(identifier)
+    }
+
+    fn visit_sorted_identifier(
+        &mut self,
+        identifier: Identifier<V::Symbol>,
+        sort: V::Sort,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_sorted_identifier(identifier, sort)
+    }
+}
+
+impl<R, V> TermVisitor<V::Constant, V::QualIdentifier, V::Keyword, V::SExpr, V::Symbol, V::Sort>
+    for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Term;
+    type E = R::Error;
+
+    fn visit_constant(&mut self, constant: V::Constant) -> Result<Self::T, Self::E> {
+        self.visit_constant(constant)
+    }
+
+    fn visit_qual_identifier(
+        &mut self,
+        qual_identifier: V::QualIdentifier,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_qual_identifier(qual_identifier)
+    }
+
+    fn visit_application(
+        &mut self,
+        qual_identifier: V::QualIdentifier,
+        arguments: Vec<Self::T>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_application(qual_identifier, arguments)
+    }
+
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(V::Symbol, Self::T)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_let(var_bindings, term)
+    }
+
+    fn visit_forall(
+        &mut self,
+        vars: Vec<(V::Symbol, V::Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_forall(vars, term)
+    }
+
+    fn visit_exists(
+        &mut self,
+        vars: Vec<(V::Symbol, V::Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_exists(vars, term)
+    }
+
+    fn visit_match(
+        &mut self,
+        term: Self::T,
+        cases: Vec<(Vec<V::Symbol>, Self::T)>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_match(term, cases)
+    }
+
+    fn visit_attributes(
+        &mut self,
+        term: Self::T,
+        attributes: Vec<(V::Keyword, AttributeValue<V::Constant, V::Symbol, V::SExpr>)>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_attributes(term, attributes)
+    }
+}
+
+impl<R, V> CommandVisitor<V::Term, V::Symbol, V::Sort, V::Keyword, V::Constant, V::SExpr> for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type T = V::Command;
+    type E = R::Error;
+
+    fn visit_assert(&mut self, term: V::Term) -> Result<Self::T, Self::E> {
+        self.visit_assert(term)
+    }
+
+    fn visit_check_sat(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_check_sat()
+    }
+
+    fn visit_check_sat_assuming(
+        &mut self,
+        literals: Vec<(V::Symbol, bool)>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_check_sat_assuming(literals)
+    }
+
+    fn visit_declare_const(
+        &mut self,
+        symbol: V::Symbol,
+        sort: V::Sort,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_declare_const(symbol, sort)
+    }
+
+    fn visit_declare_datatype(
+        &mut self,
+        symbol: V::Symbol,
+        datatype: DatatypeDec<V::Symbol, V::Sort>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_declare_datatype(symbol, datatype)
+    }
+
+    fn visit_declare_datatypes(
+        &mut self,
+        datatypes: Vec<(V::Symbol, Numeral, DatatypeDec<V::Symbol, V::Sort>)>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_declare_datatypes(datatypes)
+    }
+
+    fn visit_declare_fun(
+        &mut self,
+        symbol: V::Symbol,
+        parameters: Vec<V::Sort>,
+        sort: V::Sort,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_declare_fun(symbol, parameters, sort)
+    }
+
+    fn visit_declare_sort(
+        &mut self,
+        symbol: V::Symbol,
+        arity: Numeral,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_declare_sort(symbol, arity)
+    }
+
+    fn visit_define_fun(
+        &mut self,
+        sig: FunctionDec<V::Symbol, V::Sort>,
+        term: V::Term,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_define_fun(sig, term)
+    }
+
+    fn visit_define_fun_rec(
+        &mut self,
+        sig: FunctionDec<V::Symbol, V::Sort>,
+        term: V::Term,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_define_fun_rec(sig, term)
+    }
+
+    fn visit_define_funs_rec(
+        &mut self,
+        funs: Vec<(FunctionDec<V::Symbol, V::Sort>, V::Term)>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_define_funs_rec(funs)
+    }
+
+    fn visit_define_sort(
+        &mut self,
+        symbol: V::Symbol,
+        parameters: Vec<V::Symbol>,
+        sort: V::Sort,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_define_sort(symbol, parameters, sort)
+    }
+
+    fn visit_echo(&mut self, message: String) -> Result<Self::T, Self::E> {
+        self.visit_echo(message)
+    }
+
+    fn visit_exit(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_exit()
+    }
+
+    fn visit_get_assertions(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_get_assertions()
+    }
+
+    fn visit_get_assignment(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_get_assignment()
+    }
+
+    fn visit_get_info(&mut self, flag: V::Keyword) -> Result<Self::T, Self::E> {
+        self.visit_get_info(flag)
+    }
+
+    fn visit_get_model(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_get_model()
+    }
+
+    fn visit_get_option(&mut self, keyword: V::Keyword) -> Result<Self::T, Self::E> {
+        self.visit_get_option(keyword)
+    }
+
+    fn visit_get_proof(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_get_proof()
+    }
+
+    fn visit_get_unsat_assumptions(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_get_unsat_assumptions()
+    }
+
+    fn visit_get_unsat_core(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_get_unsat_core()
+    }
+
+    fn visit_get_value(&mut self, terms: Vec<V::Term>) -> Result<Self::T, Self::E> {
+        self.visit_get_value(terms)
+    }
+
+    fn visit_pop(&mut self, level: Numeral) -> Result<Self::T, Self::E> {
+        self.visit_pop(level)
+    }
+
+    fn visit_push(&mut self, level: Numeral) -> Result<Self::T, Self::E> {
+        self.visit_push(level)
+    }
+
+    fn visit_reset(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_reset()
+    }
+
+    fn visit_reset_assertions(&mut self) -> Result<Self::T, Self::E> {
+        self.visit_reset_assertions()
+    }
+
+    fn visit_set_info(
+        &mut self,
+        keyword: V::Keyword,
+        value: AttributeValue<V::Constant, V::Symbol, V::SExpr>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_set_info(keyword, value)
+    }
+
+    fn visit_set_logic(&mut self, symbol: V::Symbol) -> Result<Self::T, Self::E> {
+        self.visit_set_logic(symbol)
+    }
+
+    fn visit_set_option(
+        &mut self,
+        keyword: V::Keyword,
+        value: AttributeValue<V::Constant, V::Symbol, V::SExpr>,
+    ) -> Result<Self::T, Self::E> {
+        self.visit_set_option(keyword, value)
+    }
+}
+
+impl<R, V> Smt2Visitor for R
+where
+    R: Rewriter<V = V>,
+    V: Smt2Visitor,
+{
+    type Error = R::Error;
+    type Constant = V::Constant;
+    type QualIdentifier = V::QualIdentifier;
+    type Keyword = V::Keyword;
+    type Sort = V::Sort;
+    type SExpr = V::SExpr;
+    type Symbol = V::Symbol;
+    type Term = V::Term;
+    type Command = V::Command;
+
+    fn syntax_error(&mut self, pos: Position, s: String) -> Self::Error {
+        self.visitor().syntax_error(pos, s).into()
+    }
+
+    fn parsing_error(&mut self, pos: Position, s: String) -> Self::Error {
+        self.visitor().parsing_error(pos, s).into()
+    }
+}
+
+#[test]
+fn test_term_rewriter() {
+    use crate::smt2parser::concrete::*;
+
+    // (assert (let ((x (f x 2))) (= x 3)))
+    let command = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+
+    #[derive(Default)]
+    struct Builder(crate::smt2parser::concrete::SyntaxBuilder);
+    impl Rewriter for Builder {
+        type V = crate::smt2parser::concrete::SyntaxBuilder;
+        type Error = crate::smt2parser::concrete::Error;
+
+        fn visitor(&mut self) -> &mut Self::V {
+            &mut self.0
+        }
+
+        fn process_symbol(&mut self, s: Symbol) -> Result<Symbol, Self::Error> {
+            Ok(Symbol(s.0 + "__"))
+        }
+    }
+
+    let mut builder = Builder::default();
+
+    let command2 = command.clone().accept(&mut builder).unwrap();
+    let command3 = Command::Assert {
+        term: Term::Let {
+            var_bindings: vec![(
+                Symbol("x__".into()),
+                Term::Application {
+                    qual_identifier: QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("f__".into()),
+                        },
+                    },
+                    arguments: vec![
+                        Term::QualIdentifier(QualIdentifier::Simple {
+                            identifier: Identifier::Simple {
+                                symbol: Symbol("x__".into()),
+                            },
+                        }),
+                        Term::Constant(Constant::Numeral(num::BigUint::from(2u32))),
+                    ],
+                },
+            )],
+            term: Box::new(Term::Application {
+                qual_identifier: QualIdentifier::Simple {
+                    identifier: Identifier::Simple {
+                        symbol: Symbol("=__".into()),
+                    },
+                },
+                arguments: vec![
+                    Term::QualIdentifier(QualIdentifier::Simple {
+                        identifier: Identifier::Simple {
+                            symbol: Symbol("x__".into()),
+                        },
+                    }),
+                    Term::Constant(Constant::Numeral(num::BigUint::from(3u32))),
+                ],
+            }),
+        },
+    };
+
+    assert_eq!(command2, command3);
+
+    #[derive(Default)]
+    struct Builder2(crate::smt2parser::concrete::SyntaxBuilder);
+    impl Rewriter for Builder2 {
+        type V = crate::smt2parser::concrete::SyntaxBuilder;
+        type Error = crate::smt2parser::concrete::Error;
+
+        fn visitor(&mut self) -> &mut Self::V {
+            &mut self.0
+        }
+
+        fn visit_assert(&mut self, _: Term) -> Result<Command, Self::Error> {
+            Ok(Command::Exit)
+        }
+    }
+
+    let mut builder = Builder2::default();
+
+    let command2 = command.accept(&mut builder).unwrap();
+    let command3 = Command::Exit;
+    assert_eq!(command2, command3);
+}

--- a/aws-smt-ir/src/smt2parser/visitors.rs
+++ b/aws-smt-ir/src/smt2parser/visitors.rs
@@ -1,0 +1,602 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Modifications: Copyright (c) Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//! The visiting traits expected by the SMT2 parser.
+
+use crate::smt2parser::{Binary, Decimal, Hexadecimal, Numeral};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+
+pub trait ConstantVisitor {
+    type T;
+    type E;
+
+    fn visit_numeral_constant(&mut self, value: Numeral) -> Result<Self::T, Self::E>;
+    fn visit_decimal_constant(&mut self, value: Decimal) -> Result<Self::T, Self::E>;
+    fn visit_hexadecimal_constant(&mut self, value: Hexadecimal) -> Result<Self::T, Self::E>;
+    fn visit_binary_constant(&mut self, value: Binary) -> Result<Self::T, Self::E>;
+    fn visit_string_constant(&mut self, value: String) -> Result<Self::T, Self::E>;
+}
+
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, Hash, EnumIter)]
+pub enum SymbolKind {
+    Unknown,
+    Variable,
+    Constant,
+    Function,
+    Sort,
+    Datatype,
+    TypeVar,
+    Constructor,
+    Selector,
+}
+
+pub trait SymbolVisitor {
+    type T;
+    type E;
+
+    fn visit_fresh_symbol(&mut self, value: String, kind: SymbolKind) -> Result<Self::T, Self::E>;
+
+    fn visit_bound_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_fresh_symbol(value, SymbolKind::Unknown)
+    }
+
+    // If the symbol is not a valid bound symbol, try to create a fresh one.
+    fn visit_any_symbol(&mut self, value: String) -> Result<Self::T, Self::E> {
+        self.visit_bound_symbol(value.clone())
+            .or_else(|_| self.visit_fresh_symbol(value, SymbolKind::Unknown))
+    }
+
+    fn bind_symbol(&mut self, _symbol: &Self::T) {}
+
+    fn unbind_symbol(&mut self, _symbol: &Self::T) {}
+}
+
+pub trait KeywordVisitor {
+    type T;
+    type E;
+
+    fn visit_keyword(&mut self, value: String) -> Result<Self::T, Self::E>;
+}
+
+pub trait SExprVisitor<Constant, Symbol, Keyword> {
+    type T;
+    type E;
+
+    fn visit_constant_s_expr(&mut self, value: Constant) -> Result<Self::T, Self::E>;
+    fn visit_symbol_s_expr(&mut self, value: Symbol) -> Result<Self::T, Self::E>;
+    fn visit_keyword_s_expr(&mut self, value: Keyword) -> Result<Self::T, Self::E>;
+    fn visit_application_s_expr(&mut self, values: Vec<Self::T>) -> Result<Self::T, Self::E>;
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum Index<Symbol = crate::smt2parser::concrete::Symbol> {
+    Numeral(Numeral),
+    Symbol(Symbol),
+}
+
+impl<S> Index<S> {
+    /// Remap the symbols of an Index value.
+    pub(crate) fn remap<F, V, T, E>(self, v: &mut V, f: F) -> Result<Index<T>, E>
+    where
+        F: Copy + Fn(&mut V, S) -> Result<T, E>,
+    {
+        use Index::*;
+        match self {
+            Numeral(n) => Ok(Numeral(n)),
+            Symbol(s) => Ok(Symbol(f(v, s)?)),
+        }
+    }
+}
+
+/// Concrete identifier.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum Identifier<Symbol = crate::smt2parser::concrete::Symbol> {
+    Simple {
+        symbol: Symbol,
+    },
+    Indexed {
+        symbol: Symbol,
+        indices: Vec<Index<Symbol>>,
+    },
+}
+
+impl<S> Identifier<S> {
+    /// Remap the symbols of an Identifier value.
+    pub(crate) fn remap<F, V, T, E>(self, v: &mut V, f: F) -> Result<Identifier<T>, E>
+    where
+        F: Copy + Fn(&mut V, S) -> Result<T, E>,
+    {
+        use Identifier::*;
+        match self {
+            Simple { symbol } => Ok(Simple {
+                symbol: f(v, symbol)?,
+            }),
+            Indexed { symbol, indices } => Ok(Indexed {
+                symbol: f(v, symbol)?,
+                indices: indices
+                    .into_iter()
+                    .map(|i| i.remap(v, f))
+                    .collect::<Result<_, E>>()?,
+            }),
+        }
+    }
+}
+
+pub trait SortVisitor<Symbol> {
+    type T;
+    type E;
+
+    fn visit_simple_sort(&mut self, identifier: Identifier<Symbol>) -> Result<Self::T, Self::E>;
+    fn visit_parameterized_sort(
+        &mut self,
+        identifier: Identifier<Symbol>,
+        parameters: Vec<Self::T>,
+    ) -> Result<Self::T, Self::E>;
+}
+
+pub trait QualIdentifierVisitor<Identifier, Sort> {
+    type T;
+    type E;
+
+    fn visit_simple_identifier(&mut self, identifier: Identifier) -> Result<Self::T, Self::E>;
+    fn visit_sorted_identifier(
+        &mut self,
+        identifier: Identifier,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E>;
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub enum AttributeValue<
+    Constant = crate::smt2parser::concrete::Constant,
+    Symbol = crate::smt2parser::concrete::Symbol,
+    SExpr = crate::smt2parser::concrete::SExpr,
+> {
+    None,
+    Constant(Constant),
+    Symbol(Symbol),
+    SExpr(Vec<SExpr>),
+}
+
+impl<T1, T2, T3> AttributeValue<T1, T2, T3> {
+    /// Remap the generically-typed values of an AttributeValue.
+    pub(crate) fn remap<V, F1, F2, F3, R1, R2, R3, E>(
+        self,
+        v: &mut V,
+        fcst: F1,
+        fsym: F2,
+        fsexp: F3,
+    ) -> Result<AttributeValue<R1, R2, R3>, E>
+    where
+        F1: Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Fn(&mut V, T2) -> Result<R2, E>,
+        F3: Fn(&mut V, T3) -> Result<R3, E>,
+    {
+        use AttributeValue::*;
+        let value = match self {
+            None => None,
+            Constant(value) => Constant(fcst(v, value)?),
+            Symbol(value) => Symbol(fsym(v, value)?),
+            SExpr(values) => SExpr(
+                values
+                    .into_iter()
+                    .map(|x| fsexp(v, x))
+                    .collect::<Result<_, E>>()?,
+            ),
+        };
+        Ok(value)
+    }
+}
+
+pub trait TermVisitor<Constant, QualIdentifier, Keyword, SExpr, Symbol, Sort> {
+    type T;
+    type E;
+
+    fn visit_constant(&mut self, constant: Constant) -> Result<Self::T, Self::E>;
+
+    fn visit_qual_identifier(
+        &mut self,
+        qual_identifier: QualIdentifier,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_application(
+        &mut self,
+        qual_identifier: QualIdentifier,
+        arguments: Vec<Self::T>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_let(
+        &mut self,
+        var_bindings: Vec<(Symbol, Self::T)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_forall(
+        &mut self,
+        vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_exists(
+        &mut self,
+        vars: Vec<(Symbol, Sort)>,
+        term: Self::T,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_match(
+        &mut self,
+        term: Self::T,
+        cases: Vec<(Vec<Symbol>, Self::T)>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_attributes(
+        &mut self,
+        term: Self::T,
+        attributes: Vec<(Keyword, AttributeValue<Constant, Symbol, SExpr>)>,
+    ) -> Result<Self::T, Self::E>;
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct ConstructorDec<Symbol, Sort> {
+    pub symbol: Symbol,
+    pub selectors: Vec<(Symbol, Sort)>,
+}
+
+impl<T1, T2> ConstructorDec<T1, T2> {
+    /// Remap the generically-typed values of a ConstructorDec value.
+    /// Note: Constructor symbols and selector symbols are remapped using distinct function `fcons` and `fsel`.
+    pub(crate) fn remap<V, F1, F2, F3, R1, R2, E>(
+        self,
+        v: &mut V,
+        fcons: F1,
+        fsel: F2,
+        fsort: F3,
+    ) -> Result<ConstructorDec<R1, R2>, E>
+    where
+        F1: Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Fn(&mut V, T1) -> Result<R1, E>,
+        F3: Fn(&mut V, T2) -> Result<R2, E>,
+    {
+        Ok(ConstructorDec {
+            symbol: fcons(v, self.symbol)?,
+            selectors: self
+                .selectors
+                .into_iter()
+                .map(|(s1, s2)| Ok((fsel(v, s1)?, fsort(v, s2)?)))
+                .collect::<Result<_, E>>()?,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct DatatypeDec<Symbol = crate::smt2parser::concrete::Symbol, Sort = crate::smt2parser::concrete::Sort> {
+    pub parameters: Vec<Symbol>,
+    pub constructors: Vec<ConstructorDec<Symbol, Sort>>,
+}
+
+impl<T1, T2> DatatypeDec<T1, T2> {
+    /// Remap the generically-typed values of a DatatypeDec value.
+    pub(crate) fn remap<V, F1, F2, F3, F4, R1, R2, E>(
+        self,
+        v: &mut V,
+        fpar: F1,
+        fcons: F2,
+        fsel: F3,
+        fsort: F4,
+    ) -> Result<DatatypeDec<R1, R2>, E>
+    where
+        F1: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F3: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F4: Copy + Fn(&mut V, T2) -> Result<R2, E>,
+    {
+        Ok(DatatypeDec {
+            parameters: self
+                .parameters
+                .into_iter()
+                .map(|x| fpar(v, x))
+                .collect::<Result<_, E>>()?,
+            constructors: self
+                .constructors
+                .into_iter()
+                .map(|c| c.remap(v, fcons, fsel, fsort))
+                .collect::<Result<_, E>>()?,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct FunctionDec<Symbol = crate::smt2parser::concrete::Symbol, Sort = crate::smt2parser::concrete::Sort> {
+    pub name: Symbol,
+    pub parameters: Vec<(Symbol, Sort)>,
+    pub result: Sort,
+}
+
+impl<T1, T2> FunctionDec<T1, T2> {
+    /// Remap the generically-typed values of a FunctionDec value.
+    pub(crate) fn remap<V, F1, F2, F3, R1, R2, E>(
+        self,
+        v: &mut V,
+        ffun: F1,
+        fvar: F2,
+        fsort: F3,
+    ) -> Result<FunctionDec<R1, R2>, E>
+    where
+        F1: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F2: Copy + Fn(&mut V, T1) -> Result<R1, E>,
+        F3: Copy + Fn(&mut V, T2) -> Result<R2, E>,
+    {
+        Ok(FunctionDec {
+            name: ffun(v, self.name)?,
+            parameters: self
+                .parameters
+                .into_iter()
+                .map(|(s1, s2)| Ok((fvar(v, s1)?, fsort(v, s2)?)))
+                .collect::<Result<_, E>>()?,
+            result: fsort(v, self.result)?,
+        })
+    }
+}
+
+pub trait CommandVisitor<Term, Symbol, Sort, Keyword, Constant, SExpr> {
+    type T;
+    type E;
+
+    fn visit_assert(&mut self, term: Term) -> Result<Self::T, Self::E>;
+
+    fn visit_check_sat(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_check_sat_assuming(
+        &mut self,
+        literals: Vec<(Symbol, bool)>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_declare_const(&mut self, symbol: Symbol, sort: Sort) -> Result<Self::T, Self::E>;
+
+    fn visit_declare_datatype(
+        &mut self,
+        symbol: Symbol,
+        datatype: DatatypeDec<Symbol, Sort>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_declare_datatypes(
+        &mut self,
+        datatypes: Vec<(Symbol, Numeral, DatatypeDec<Symbol, Sort>)>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_declare_fun(
+        &mut self,
+        symbol: Symbol,
+        parameters: Vec<Sort>,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_declare_sort(&mut self, symbol: Symbol, arity: Numeral) -> Result<Self::T, Self::E>;
+
+    fn visit_define_fun(
+        &mut self,
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_define_fun_rec(
+        &mut self,
+        sig: FunctionDec<Symbol, Sort>,
+        term: Term,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_define_funs_rec(
+        &mut self,
+        funs: Vec<(FunctionDec<Symbol, Sort>, Term)>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_define_sort(
+        &mut self,
+        symbol: Symbol,
+        parameters: Vec<Symbol>,
+        sort: Sort,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_echo(&mut self, message: String) -> Result<Self::T, Self::E>;
+
+    fn visit_exit(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_assertions(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_assignment(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_info(&mut self, flag: Keyword) -> Result<Self::T, Self::E>;
+
+    fn visit_get_model(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_option(&mut self, keyword: Keyword) -> Result<Self::T, Self::E>;
+
+    fn visit_get_proof(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_unsat_assumptions(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_unsat_core(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_get_value(&mut self, terms: Vec<Term>) -> Result<Self::T, Self::E>;
+
+    fn visit_pop(&mut self, level: Numeral) -> Result<Self::T, Self::E>;
+
+    fn visit_push(&mut self, level: Numeral) -> Result<Self::T, Self::E>;
+
+    fn visit_reset(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_reset_assertions(&mut self) -> Result<Self::T, Self::E>;
+
+    fn visit_set_info(
+        &mut self,
+        keyword: Keyword,
+        value: AttributeValue<Constant, Symbol, SExpr>,
+    ) -> Result<Self::T, Self::E>;
+
+    fn visit_set_logic(&mut self, symbol: Symbol) -> Result<Self::T, Self::E>;
+
+    fn visit_set_option(
+        &mut self,
+        keyword: Keyword,
+        value: AttributeValue<Constant, Symbol, SExpr>,
+    ) -> Result<Self::T, Self::E>;
+}
+
+/// A visitor for the entire SMT2 syntax.
+pub trait Smt2Visitor:
+    ConstantVisitor<T = <Self as Smt2Visitor>::Constant, E = <Self as Smt2Visitor>::Error>
+    + SymbolVisitor<T = <Self as Smt2Visitor>::Symbol, E = <Self as Smt2Visitor>::Error>
+    + KeywordVisitor<T = <Self as Smt2Visitor>::Keyword, E = <Self as Smt2Visitor>::Error>
+    + SExprVisitor<
+        <Self as Smt2Visitor>::Constant,
+        <Self as Smt2Visitor>::Symbol,
+        <Self as Smt2Visitor>::Keyword,
+        T = <Self as Smt2Visitor>::SExpr,
+        E = <Self as Smt2Visitor>::Error,
+    > + QualIdentifierVisitor<
+        Identifier<<Self as Smt2Visitor>::Symbol>,
+        <Self as Smt2Visitor>::Sort,
+        T = <Self as Smt2Visitor>::QualIdentifier,
+        E = <Self as Smt2Visitor>::Error,
+    > + SortVisitor<
+        <Self as Smt2Visitor>::Symbol,
+        T = <Self as Smt2Visitor>::Sort,
+        E = <Self as Smt2Visitor>::Error,
+    > + TermVisitor<
+        <Self as Smt2Visitor>::Constant,
+        <Self as Smt2Visitor>::QualIdentifier,
+        <Self as Smt2Visitor>::Keyword,
+        <Self as Smt2Visitor>::SExpr,
+        <Self as Smt2Visitor>::Symbol,
+        <Self as Smt2Visitor>::Sort,
+        T = <Self as Smt2Visitor>::Term,
+        E = <Self as Smt2Visitor>::Error,
+    > + CommandVisitor<
+        <Self as Smt2Visitor>::Term,
+        <Self as Smt2Visitor>::Symbol,
+        <Self as Smt2Visitor>::Sort,
+        <Self as Smt2Visitor>::Keyword,
+        <Self as Smt2Visitor>::Constant,
+        <Self as Smt2Visitor>::SExpr,
+        T = <Self as Smt2Visitor>::Command,
+        E = <Self as Smt2Visitor>::Error,
+    >
+{
+    type Error;
+    type Constant;
+    type QualIdentifier;
+    type Keyword;
+    type Sort;
+    type SExpr;
+    type Symbol;
+    type Term;
+    type Command;
+
+    fn syntax_error(&mut self, position: crate::smt2parser::Position, s: String) -> Self::Error;
+    fn parsing_error(&mut self, position: crate::smt2parser::Position, s: String) -> Self::Error;
+}
+
+impl<Symbol> std::fmt::Display for Index<Symbol>
+where
+    Symbol: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨numeral⟩ | ⟨symbol⟩
+        match self {
+            Index::Numeral(num) => write!(f, "{}", num),
+            Index::Symbol(sym) => write!(f, "{}", sym),
+        }
+    }
+}
+
+impl<Symbol> std::fmt::Display for Identifier<Symbol>
+where
+    Symbol: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨symbol⟩ | ( _ ⟨symbol⟩ ⟨index⟩+ )
+        match self {
+            Identifier::Simple { symbol } => write!(f, "{}", symbol),
+            Identifier::Indexed { symbol, indices } => {
+                write!(f, "(_ {} {})", symbol, indices.iter().format(" "))
+            }
+        }
+    }
+}
+
+impl<Constant, Symbol, SExpr> std::fmt::Display for AttributeValue<Constant, Symbol, SExpr>
+where
+    Constant: std::fmt::Display,
+    Symbol: std::fmt::Display,
+    SExpr: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨spec_constant⟩ | ⟨symbol⟩ | ( ⟨s_expr⟩∗ ) |
+        use AttributeValue::*;
+        match self {
+            None => Ok(()),
+            Constant(c) => write!(f, "{}", c),
+            Symbol(s) => write!(f, "{}", s),
+            SExpr(values) => write!(f, "({})", values.iter().format(" ")),
+        }
+    }
+}
+
+impl<Symbol, Sort> std::fmt::Display for ConstructorDec<Symbol, Sort>
+where
+    Symbol: std::fmt::Display,
+    Sort: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ( ⟨symbol⟩ ⟨selector_dec⟩∗ )
+        write!(
+            f,
+            "({} {})",
+            self.symbol,
+            self.selectors
+                .iter()
+                .format_with(" ", |(symbol, sort), f| f(&format_args!(
+                    "({} {})",
+                    symbol, sort
+                )))
+        )
+    }
+}
+
+impl<Symbol, Sort> std::fmt::Display for DatatypeDec<Symbol, Sort>
+where
+    Symbol: std::fmt::Display,
+    Sort: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ( ⟨constructor_dec⟩+ ) | ( par ( ⟨symbol⟩+ ) ( ⟨constructor_dec⟩+ ) )
+        if self.parameters.is_empty() {
+            write!(f, "({})", self.constructors.iter().format(" "))
+        } else {
+            let symbols = format!("({})", self.parameters.iter().format(" "));
+            let constructors = format!("({})", self.constructors.iter().format(" "));
+            write!(f, "(par {} {})", symbols, constructors)
+        }
+    }
+}
+
+impl<Symbol, Sort> std::fmt::Display for FunctionDec<Symbol, Sort>
+where
+    Symbol: std::fmt::Display,
+    Sort: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // ⟨symbol⟩ ( ⟨sorted_var⟩∗ ) ⟨sort⟩
+        let params = self
+            .parameters
+            .iter()
+            .format_with(" ", |(symbol, sort), f| {
+                f(&format_args!("({} {})", symbol, sort))
+            });
+        write!(f, "{} ({}) {}", self.name, params, self.result)
+    }
+}

--- a/aws-smt-ir/src/smt2parser/visitors.rs
+++ b/aws-smt-ir/src/smt2parser/visitors.rs
@@ -273,7 +273,10 @@ impl<T1, T2> ConstructorDec<T1, T2> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
-pub struct DatatypeDec<Symbol = crate::smt2parser::concrete::Symbol, Sort = crate::smt2parser::concrete::Sort> {
+pub struct DatatypeDec<
+    Symbol = crate::smt2parser::concrete::Symbol,
+    Sort = crate::smt2parser::concrete::Sort,
+> {
     pub parameters: Vec<Symbol>,
     pub constructors: Vec<ConstructorDec<Symbol, Sort>>,
 }
@@ -310,7 +313,10 @@ impl<T1, T2> DatatypeDec<T1, T2> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
-pub struct FunctionDec<Symbol = crate::smt2parser::concrete::Symbol, Sort = crate::smt2parser::concrete::Sort> {
+pub struct FunctionDec<
+    Symbol = crate::smt2parser::concrete::Symbol,
+    Sort = crate::smt2parser::concrete::Sort,
+> {
     pub name: Symbol,
     pub parameters: Vec<(Symbol, Sort)>,
     pub result: Sort,

--- a/aws-smt-ir/src/term.rs
+++ b/aws-smt-ir/src/term.rs
@@ -38,7 +38,7 @@ pub use uf::UF;
 /// ```
 /// # fn main() {
 /// use aws_smt_ir::{CoreOp, Term, Void};
-/// use smt2parser::concrete::Constant;
+/// use aws_smt_ir::smt2parser::concrete::Constant;
 ///
 /// let constant: Term = Term::Constant(Constant::Numeral(0u8.into()).into());
 /// let variable = Term::Variable("x".into());

--- a/aws-smt-ir/src/term/operation.rs
+++ b/aws-smt-ir/src/term/operation.rs
@@ -19,7 +19,7 @@ use std::fmt;
 /// ```
 /// # fn main() {
 /// use aws_smt_ir::{fold::Fold, visit::Visit, Term, Operation, Logic, Void, QualIdentifier, ISort, UnknownSort, Sorted, Ctx};
-/// use smt2parser::concrete::Constant;
+/// use aws_smt_ir::smt2parser::concrete::Constant;
 ///
 /// #[derive(Operation, Fold, Visit, Clone, Hash, PartialEq, Eq)]
 /// enum Math<Term> {

--- a/aws-smt-ir/src/types.rs
+++ b/aws-smt-ir/src/types.rs
@@ -5,13 +5,13 @@ use super::{
     visit::{ControlFlow, SuperVisit, Visitor},
     CoreOp, Let, Logic, Match, Quantifier, Term, UF,
 };
-use internment::Intern;
-use num_traits::ToPrimitive;
-use once_cell::sync::Lazy;
-pub use smt2parser::{
+pub use crate::smt2parser::{
     concrete::{Constant, Identifier, Keyword, Symbol},
     Binary, Decimal, Hexadecimal, Numeral,
 };
+use internment::Intern;
+use num_traits::ToPrimitive;
+use once_cell::sync::Lazy;
 use std::{
     borrow::Borrow,
     cmp::Ordering,
@@ -22,12 +22,12 @@ use std::{
 };
 
 pub type Command<Term> =
-    smt2parser::concrete::Command<Term, ISymbol, ISort, Keyword, IConst, SExpr>;
-pub type SExpr = smt2parser::concrete::SExpr<IConst, ISymbol, Keyword>;
-pub type Index = smt2parser::visitors::Index<ISymbol>;
-pub type DatatypeDec = smt2parser::concrete::DatatypeDec<ISymbol, ISort>;
-pub type FunctionDec = smt2parser::concrete::FunctionDec<ISymbol, ISort>;
-pub type AttributeValue = smt2parser::concrete::AttributeValue<IConst, ISymbol, SExpr>;
+    crate::smt2parser::concrete::Command<Term, ISymbol, ISort, Keyword, IConst, SExpr>;
+pub type SExpr = crate::smt2parser::concrete::SExpr<IConst, ISymbol, Keyword>;
+pub type Index = crate::smt2parser::visitors::Index<ISymbol>;
+pub type DatatypeDec = crate::smt2parser::concrete::DatatypeDec<ISymbol, ISort>;
+pub type FunctionDec = crate::smt2parser::concrete::FunctionDec<ISymbol, ISort>;
+pub type AttributeValue = crate::smt2parser::concrete::AttributeValue<IConst, ISymbol, SExpr>;
 
 /// An identifier possibly annotated with a sort.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -53,7 +53,7 @@ impl Sort {
     pub fn bv_width(&self) -> Option<&Numeral> {
         match self {
             Sort::Simple { identifier } => match identifier.as_ref() {
-                smt2parser::concrete::Identifier::Indexed { symbol, indices } => {
+                crate::smt2parser::concrete::Identifier::Indexed { symbol, indices } => {
                     match (symbol.as_ref().0.as_ref(), indices.as_slice()) {
                         ("BitVec", [Index::Numeral(n)]) => Some(n),
                         _ => None,


### PR DESCRIPTION
*Remove dependency from smt2parser 0.6*

Smt2parser and some crates it depends on are non-longer maintained. One of these crates `atty` has a security vulnerability. This pull request imports a subset of smt2parser as a new module to fix this issue.

Other fixes:
- two bugs in smt2parser: improper syntax for the `get-value` command and failure to parse term attributes that contain keywords are tied.
- better error processing
- small cleanup to fix compiler warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
