### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## rust-smt-ir
 
 This project provides an intermediate representation (IR) in Rust for
-[SMT-LIB](http://smtlib.cs.uiowa.edu/about.shtml) queries along with
+[SMT-LIB](https://smt-lib.org/about.shtml) queries along with
 tools for performing computations over queries and transforming
 queries in various ways.
 


### PR DESCRIPTION
*Description of changes:*

The link in the readme to SMT-LIB does not work. I gather the intention is to link to the replacement link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
